### PR TITLE
[BF-PA] Add dashboard and report pages for BF-PA DA

### DIFF
--- a/navigation/index.js
+++ b/navigation/index.js
@@ -1600,6 +1600,23 @@ export default [
         ],
         meta: {},
       },
+      {
+        title: "Pelaporan",
+        icon: "iconamoon:component-fill",
+        child: [
+          {
+            title: "Dashboard",
+            icon: "iconamoon:arrow-right-2-duotone",
+            path: "/BF-PA/DA/dashboard",
+            child: [],
+            meta: {},
+          },
+         
+          
+          
+        ],
+        meta: {},
+      },
     ],
     meta: {
       auth: {

--- a/pages/BF-PA/DA/dashboard/index.vue
+++ b/pages/BF-PA/DA/dashboard/index.vue
@@ -1,0 +1,682 @@
+<template>
+  <div>
+    <!-- Breadcrumb -->
+    <LayoutsBreadcrumb :items="breadcrumb" />
+
+    <!-- ===== 3.1.1 Filter Bar ===== -->
+    <rs-card class="mt-4">
+      <template #header>
+        <div class="flex items-center justify-between w-full">
+          <div class="flex items-center gap-2">
+            <Icon name="material-symbols:tune" />
+            <span class="font-semibold">Filter Bar</span>
+          </div>
+          <div class="flex items-center gap-2">
+            <rs-button variant="primary" @click="onApply">Tapis</rs-button>
+            <rs-button variant="danger" @click="onReset">Set Semula</rs-button>
+          </div>
+        </div>
+      </template>
+      <template #body>
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <!-- Tahun -->
+          <FormKit
+            type="select"
+            v-model="filters.tahun"
+            label="Tahun"
+            :options="tahunOptions"
+            :classes="{ label: 'text-sm font-medium', input: '!py-2' }"
+          />
+
+          <!-- Bulan -->
+          <FormKit
+            type="select"
+            v-model="filters.bulan"
+            label="Bulan"
+            :options="bulanOptions"
+            :classes="{ label: 'text-sm font-medium', input: '!py-2' }"
+          />
+
+          <!-- Daerah -->
+          <FormKit
+            type="select"
+            v-model="filters.daerah"
+            label="Daerah"
+            :options="daerahOptions"
+            :classes="{ label: 'text-sm font-medium', input: '!py-2' }"
+          />
+
+          <!-- Kategori PA -->
+          <FormKit
+            type="select"
+            v-model="filters.kategori"
+            label="Kategori PA"
+            :options="kategoriOptions"
+            :classes="{ label: 'text-sm font-medium', input: '!py-2' }"
+          />
+
+          <!-- Jenis Aktiviti -->
+          <FormKit
+            type="select"
+            v-model="filters.jenisAktiviti"
+            label="Jenis Aktiviti"
+            :options="jenisAktivitiOptions"
+            :classes="{ label: 'text-sm font-medium', input: '!py-2' }"
+          />
+
+          <!-- Status Permohonan -->
+          <FormKit
+            type="select"
+            v-model="filters.statusPermohonan"
+            label="Status Permohonan"
+            :options="statusPermohonanOptions"
+            :classes="{ label: 'text-sm font-medium', input: '!py-2' }"
+          />
+
+          <!-- Status Tugasan -->
+          <FormKit
+            type="select"
+            v-model="filters.statusTugasan"
+            label="Status Tugasan"
+            :options="statusTugasanOptions"
+            :classes="{ label: 'text-sm font-medium', input: '!py-2' }"
+          />
+
+          <!-- Placeholder to balance grid on desktop -->
+          <div class="hidden md:block"></div>
+        </div>
+      </template>
+    </rs-card>
+
+    <!-- ===== 3.2.2 Kad Ringkasan Utama ===== -->
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mt-4">
+      <div class="p-4 rounded-2xl bg-white shadow border border-gray-100">
+        <div class="flex items-center gap-3">
+          <div class="rounded-xl p-3 bg-gray-50">
+            <Icon name="mdi:account-group-outline" class="text-xl" />
+          </div>
+          <div>
+            <div class="text-xs uppercase tracking-wide text-gray-500">Bil. PA Aktif</div>
+            <div class="text-2xl font-semibold text-gray-900">{{ summary.bilPaAktif }}</div>
+          </div>
+        </div>
+      </div>
+      <div class="p-4 rounded-2xl bg-white shadow border border-gray-100">
+        <div class="flex items-center gap-3">
+          <div class="rounded-xl p-3 bg-gray-50">
+            <Icon name="mdi:file-document-outline" class="text-xl" />
+          </div>
+          <div>
+            <div class="text-xs uppercase tracking-wide text-gray-500">Bil. Permohonan (Bh/Pbh)</div>
+            <div class="text-2xl font-semibold text-gray-900">{{ summaryLabelPermohonan }}</div>
+          </div>
+        </div>
+      </div>
+      <div class="p-4 rounded-2xl bg-white shadow border border-gray-100">
+        <div class="flex items-center gap-3">
+          <div class="rounded-xl p-3 bg-gray-50">
+            <Icon name="mdi:clipboard-text-clock-outline" class="text-xl" />
+          </div>
+          <div>
+            <div class="text-xs uppercase tracking-wide text-gray-500">Bil. Tugasan Aktif</div>
+            <div class="text-2xl font-semibold text-gray-900">{{ summary.bilTugasanAktif }}</div>
+          </div>
+        </div>
+      </div>
+      <div class="p-4 rounded-2xl bg-white shadow border border-gray-100">
+        <div class="flex items-center gap-3">
+          <div class="rounded-xl p-3 bg-gray-50">
+            <Icon name="mdi:cash" class="text-xl" />
+          </div>
+          <div>
+            <div class="text-xs uppercase tracking-wide text-gray-500">Jumlah Elaun Bulan Ini (RM)</div>
+            <div class="text-2xl font-semibold text-gray-900">{{ formatRM(summary.jumlahElaunBulanIni) }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== 3.3.1 Carta PA Aktif Mengikut Kategori (Donut/Bar) ===== -->
+    <rs-card class="mt-4">
+      <template #header>
+        <div class="flex items-center justify-between w-full">
+          <div class="flex items-center gap-2">
+            <Icon name="mdi:chart-donut" />
+            <span class="font-semibold">Carta PA Aktif Mengikut Kategori</span>
+          </div>
+          <div class="flex items-center gap-2">
+            <rs-button size="sm" :variant="chartMode === 'donut' ? 'primary' : 'soft'" @click="chartMode = 'donut'">
+              Donut
+            </rs-button>
+            <rs-button size="sm" :variant="chartMode === 'bar' ? 'primary' : 'soft'" @click="chartMode = 'bar'">
+              Bar
+            </rs-button>
+          </div>
+        </div>
+      </template>
+      <template #body>
+        <div v-if="ApexChart" class="w-full">
+          <component
+            :is="ApexChart"
+            height="340"
+            :type="chartMode === 'donut' ? 'donut' : 'bar'"
+            :series="chartPAKategori.series"
+            :options="chartPAKategori.options"
+          />
+        </div>
+        <div v-else class="text-sm text-gray-500 p-4 bg-gray-50 rounded">
+          Pasang <code>vue3-apexcharts</code> untuk melihat carta. Data ringkas: {{ chartPAKategoriDebug }}
+        </div>
+      </template>
+    </rs-card>
+
+    <!-- ===== 3.3.4 Carta Permohonan (Baharu vs Pembaharuan ikut bulan) ===== -->
+    <rs-card class="mt-4">
+      <template #header>
+        <div class="flex items-center gap-2">
+          <Icon name="mdi:chart-bar" />
+          <span class="font-semibold">Carta Permohonan (Baharu vs Pembaharuan)</span>
+        </div>
+      </template>
+      <template #body>
+        <div v-if="ApexChart">
+          <component :is="ApexChart" height="340" type="bar" :series="chartPermohonan.series" :options="chartPermohonan.options" />
+        </div>
+        <div v-else class="text-sm text-gray-500 p-4 bg-gray-50 rounded">Carta memerlukan <code>vue3-apexcharts</code>.</div>
+      </template>
+    </rs-card>
+
+    <!-- ===== 3.3.1 Carta Status Permohonan (Tahap Proses) ===== -->
+    <rs-card class="mt-4">
+      <template #header>
+        <div class="flex items-center gap-2">
+          <Icon name="mdi:chart-timeline-variant-shimmer" />
+          <span class="font-semibold">Carta Status Permohonan (Draf → Sokongan → Kelulusan → Lulus/Gagal)</span>
+        </div>
+      </template>
+      <template #body>
+        <div v-if="ApexChart">
+          <component :is="ApexChart" height="320" type="bar" :series="chartStatusPermohonan.series" :options="chartStatusPermohonan.options" />
+        </div>
+        <div v-else class="text-sm text-gray-500 p-4 bg-gray-50 rounded">Carta memerlukan <code>vue3-apexcharts</code>.</div>
+      </template>
+    </rs-card>
+
+    <!-- ===== 3.3.2 Jadual Tugasan PA ===== -->
+    <rs-card class="mt-4">
+      <template #header>
+        <div class="flex items-center gap-2">
+          <Icon name="mdi:clipboard-list-outline" />
+          <span class="font-semibold">Jadual Tugasan PA</span>
+        </div>
+      </template>
+      <template #body>
+        <RsTable
+          :data="tableTugasan"
+          :columns="columnsTugasan"
+          advanced
+          :showNoColumn="false"
+          :showSearch="true"
+          :showFilter="true"
+          :options="{ variant: 'default', striped: true, hover: true }"
+          :optionsAdvanced="{ sortable: true, filterable: true, responsive: true, outsideBorder: true }"
+        >
+          <template #namaPA="{ text }">
+            <div class="font-medium">{{ text }}</div>
+          </template>
+          <template #bilBancian="{ text }"><rs-badge variant="soft">{{ text }}</rs-badge></template>
+          <template #bilSemakan="{ text }"><rs-badge variant="soft">{{ text }}</rs-badge></template>
+          <template #bilPermohonan="{ text }"><rs-badge variant="soft">{{ text }}</rs-badge></template>
+          <template #tarikhTerkini="{ text }"><span class="whitespace-nowrap">{{ formatDate(text) }}</span></template>
+          <template #statusTugasan="{ text }">
+            <rs-badge :variant="statusVariant(text)">{{ text }}</rs-badge>
+          </template>
+          <template #slaDue="{ text }">
+            <span :class="slaClass(text)">{{ text }} hari</span>
+          </template>
+        </RsTable>
+      </template>
+    </rs-card>
+
+    <!-- ===== 3.3.1 Carta Elaun PA Mengikut Bulan ===== -->
+    <rs-card class="mt-4">
+      <template #header>
+        <div class="flex items-center gap-2">
+          <Icon name="mdi:chart-line" />
+          <span class="font-semibold">Carta Elaun PA Mengikut Bulan</span>
+        </div>
+      </template>
+      <template #body>
+        <div v-if="ApexChart">
+          <component :is="ApexChart" height="340" type="line" :series="chartElaun.series" :options="chartElaun.options" />
+        </div>
+        <div v-else class="text-sm text-gray-500 p-4 bg-gray-50 rounded">Carta memerlukan <code>vue3-apexcharts</code>.</div>
+      </template>
+    </rs-card>
+
+    <!-- ===== 3.3.2 Prestasi Latihan / Program ===== -->
+    <rs-card class="mt-4">
+      <template #header>
+        <div class="flex items-center justify-between w-full">
+          <div class="flex items-center gap-2">
+            <Icon name="mdi:school-outline" />
+            <span class="font-semibold">Prestasi Latihan / Program</span>
+          </div>
+          <div>
+            <rs-button size="sm" @click="toggleProgramView">Tukar Paparan: {{ programView === 'table' ? 'Bar Chart' : 'Jadual' }}</rs-button>
+          </div>
+        </div>
+      </template>
+      <template #body>
+        <div v-if="programView === 'table'">
+          <RsTable
+            :data="tableProgram"
+            :columns="columnsProgram"
+            advanced
+            :showNoColumn="false"
+            :showSearch="true"
+            :options="{ variant: 'default', hover: true, striped: true }"
+            :optionsAdvanced="{ sortable: true, filterable: true, responsive: true }"
+          >
+            <template #tarikh="{ text }">{{ formatDate(text) }}</template>
+            <template #peratusKehadiran="{ text }">
+              <div class="flex items-center gap-2">
+                <div class="h-2 bg-gray-200 rounded w-full">
+                  <div class="h-2 rounded bg-primary-500" :style="{ width: text + '%' }"></div>
+                </div>
+                <span class="w-12 text-right">{{ text }}%</span>
+              </div>
+            </template>
+          </RsTable>
+        </div>
+        <div v-else>
+          <div v-if="ApexChart">
+            <component :is="ApexChart" height="320" type="bar" :series="chartProgram.series" :options="chartProgram.options" />
+          </div>
+          <div v-else class="text-sm text-gray-500 p-4 bg-gray-50 rounded">Carta memerlukan <code>vue3-apexcharts</code>.</div>
+        </div>
+      </template>
+    </rs-card>
+
+    <!-- ===== 2.1 Button: Jana Laporan (PD-02) ===== -->
+    <div class="mt-6 flex items-center gap-2">
+      <rs-button variant="primary" @click="goToJanaLaporan">
+            Jana Laporan
+        </rs-button>
+      <rs-button variant="danger" @click="onReset">Tapis / Set Semula</rs-button>
+    </div>
+
+    <!-- Simple Modal for PD-02 (Report Generation) -->
+    <transition name="fade">
+      <div v-if="showReport" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+        <div class="bg-white rounded-2xl shadow-xl w-full max-w-3xl">
+          <div class="px-6 py-4 border-b flex items-center justify-between">
+            <div class="font-semibold flex items-center gap-2">
+              <Icon name="mdi:file-export-outline" /> Jana Laporan (PD-02)
+            </div>
+            <button class="text-gray-500 hover:text-gray-700" @click="showReport=false">
+              <Icon name="mdi:close" />
+            </button>
+          </div>
+          <div class="p-6 space-y-4">
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <FormKit type="select" v-model="report.format" label="Format" :options="reportFormatOptions" />
+              <FormKit type="select" v-model="report.skop" label="Skop Laporan" :options="reportScopeOptions" />
+              <FormKit type="select" v-model="report.tahap" label="Tahap Perincian" :options="reportDetailOptions" />
+            </div>
+            <div class="text-sm text-gray-500">*Laporan dihasilkan berdasarkan filter semasa.</div>
+          </div>
+          <div class="px-6 py-4 border-t flex items-center justify-end gap-2">
+            <rs-button variant="soft" @click="showReport=false">Batal</rs-button>
+            <rs-button variant="primary" @click="downloadReport">Muat Turun</rs-button>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * PA-DA-PD-01 — Dashboard & Statistik (BF-PA)
+ * Single <script setup> to avoid TS/JSX issues and "multiple script" errors.
+ */
+import { ref, reactive, computed, onMounted, shallowRef } from 'vue'
+
+defineOptions({ name: 'PA-DA-PD-01' })
+
+// ===== Breadcrumb =====
+const breadcrumb = ref([
+  { name: 'Dashboard', type: 'text', path: '/' },
+  { name: 'Dashboard & Pelaporan', type: 'text', path: '#' },
+])
+
+// ===== Filters (3.1.1) =====
+const filters = reactive({
+  tahun: new Date().getFullYear().toString(),
+  bulan: (new Date().getMonth() + 1).toString().padStart(2, '0'),
+  daerah: 'ALL',
+  kategori: 'ALL',
+  jenisAktiviti: 'ALL',
+  statusPermohonan: 'ALL',
+  statusTugasan: 'ALL',
+})
+
+const tahunOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: '2023', value: '2023' },
+  { label: '2024', value: '2024' },
+  { label: '2025', value: '2025' },
+]
+const bulanOptions = [
+  { label: 'Semua', value: 'ALL' },
+  ...Array.from({ length: 12 }, (_, i) => {
+    const m = (i + 1).toString().padStart(2, '0')
+    return { label: m, value: m }
+  }),
+]
+const daerahOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Gombak', value: 'Gombak' },
+  { label: 'Hulu Langat', value: 'Hulu Langat' },
+  { label: 'Klang', value: 'Klang' },
+  { label: 'Kuala Selangor', value: 'Kuala Selangor' },
+]
+const kategoriOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Kariah', value: 'Kariah' },
+  { label: 'Institusi', value: 'Institusi' },
+  { label: 'Hospital', value: 'Hospital' },
+]
+const jenisAktivitiOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Mesyuarat', value: 'Mesyuarat' },
+  { label: 'Program', value: 'Program' },
+]
+const statusPermohonanOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Draf', value: 'Draf' },
+  { label: 'Sokongan', value: 'Sokongan' },
+  { label: 'Kelulusan', value: 'Kelulusan' },
+  { label: 'Lulus', value: 'Lulus' },
+  { label: 'Gagal', value: 'Gagal' },
+]
+const statusTugasanOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Lengkap', value: 'Lengkap' },
+  { label: 'Gagal', value: 'Gagal' },
+  { label: 'Dalam Tindakan', value: 'Dalam Tindakan' },
+]
+
+function onApply() {
+  // Computeds will react to filters automatically.
+}
+function onReset() {
+  filters.tahun = new Date().getFullYear().toString()
+  filters.bulan = 'ALL'
+  filters.daerah = 'ALL'
+  filters.kategori = 'ALL'
+  filters.jenisAktiviti = 'ALL'
+  filters.statusPermohonan = 'ALL'
+  filters.statusTugasan = 'ALL'
+}
+
+// ===== Mock Data =====
+const mockState = reactive({ nonce: 0 })
+
+const paList = ref([
+  { nama: 'Ahmad Karim', kategori: 'Kariah', status: 'Aktif', daerah: 'Gombak' },
+  { nama: 'Siti Rahmah', kategori: 'Institusi', status: 'Aktif', daerah: 'Klang' },
+  { nama: 'Lim Wei', kategori: 'Hospital', status: 'Tamat', daerah: 'Hulu Langat' },
+  { nama: 'Anand', kategori: 'Kariah', status: 'Aktif', daerah: 'Kuala Selangor' },
+  { nama: 'Zahra', kategori: 'Kariah', status: 'Dibatalkan', daerah: 'Gombak' },
+  { nama: 'Banu', kategori: 'Institusi', status: 'Aktif', daerah: 'Gombak' },
+])
+
+const permohonanMonthly = ref([
+  { month: '01', tahun: '2025', baharu: 12, pembaharuan: 20 },
+  { month: '02', tahun: '2025', baharu: 18, pembaharuan: 15 },
+  { month: '03', tahun: '2025', baharu: 22, pembaharuan: 19 },
+  { month: '04', tahun: '2025', baharu: 17, pembaharuan: 21 },
+  { month: '05', tahun: '2025', baharu: 30, pembaharuan: 25 },
+  { month: '06', tahun: '2025', baharu: 28, pembaharuan: 27 },
+  { month: '07', tahun: '2025', baharu: 24, pembaharuan: 29 },
+  { month: '08', tahun: '2025', baharu: 26, pembaharuan: 31 },
+  { month: '09', tahun: '2025', baharu: 20, pembaharuan: 18 },
+  { month: '10', tahun: '2025', baharu: 0,  pembaharuan: 0 },
+  { month: '11', tahun: '2025', baharu: 0,  pembaharuan: 0 },
+  { month: '12', tahun: '2025', baharu: 0,  pembaharuan: 0 },
+])
+
+const permohonanByStatus = ref([
+  { tahap: 'Draf', count: 18 },
+  { tahap: 'Sokongan', count: 25 },
+  { tahap: 'Kelulusan', count: 14 },
+  { tahap: 'Lulus', count: 40 },
+  { tahap: 'Gagal', count: 6 },
+])
+
+const tugasanPa = ref([
+  { namaPA: 'Ahmad Karim', bilBancian: 5, bilSemakan: 3, bilPermohonan: 2, tarikhTerkini: '2025-09-10', statusTugasan: 'Dalam Tindakan', slaDue: 2 },
+  { namaPA: 'Siti Rahmah', bilBancian: 3, bilSemakan: 5, bilPermohonan: 4, tarikhTerkini: '2025-09-09', statusTugasan: 'Lengkap', slaDue: 0 },
+  { namaPA: 'Lim Wei', bilBancian: 2, bilSemakan: 1, bilPermohonan: 1, tarikhTerkini: '2025-09-07', statusTugasan: 'Gagal', slaDue: -1 },
+  { namaPA: 'Anand', bilBancian: 6, bilSemakan: 4, bilPermohonan: 3, tarikhTerkini: '2025-09-11', statusTugasan: 'Dalam Tindakan', slaDue: 3 },
+])
+
+const elaunMonthly = ref([
+  { month: '01', tahun: '2025', paLayak: 20, jumlahRM: 3200 },
+  { month: '02', tahun: '2025', paLayak: 24, jumlahRM: 3800 },
+  { month: '03', tahun: '2025', paLayak: 27, jumlahRM: 4100 },
+  { month: '04', tahun: '2025', paLayak: 29, jumlahRM: 4600 },
+  { month: '05', tahun: '2025', paLayak: 33, jumlahRM: 5100 },
+  { month: '06', tahun: '2025', paLayak: 35, jumlahRM: 5400 },
+  { month: '07', tahun: '2025', paLayak: 36, jumlahRM: 5600 },
+  { month: '08', tahun: '2025', paLayak: 38, jumlahRM: 5900 },
+  { month: '09', tahun: '2025', paLayak: 21, jumlahRM: 3300 },
+])
+
+const programs = ref([
+  { nama: 'Latihan Asas PA', tarikh: '2025-07-15', hadir: 48, peratusKehadiran: 96 },
+  { nama: 'Program Bancian Komuniti', tarikh: '2025-08-10', hadir: 72, peratusKehadiran: 90 },
+  { nama: 'Seminar Semakan Asnaf', tarikh: '2025-09-01', hadir: 60, peratusKehadiran: 75 },
+])
+
+// ===== Derived (filters applied) =====
+const filteredPA = computed(() => paList.value.filter((x) =>
+  (filters.daerah === 'ALL' || x.daerah === filters.daerah) &&
+  (filters.kategori === 'ALL' || x.kategori === filters.kategori)
+))
+
+const filteredPermohonanMonthly = computed(() => permohonanMonthly.value
+  .filter((x) => x.tahun === filters.tahun)
+  .filter((x) => (filters.bulan === 'ALL' ? true : x.month === filters.bulan)))
+
+const filteredPermohonanByStatus = computed(() => permohonanByStatus.value)
+
+const filteredTugasan = computed(() => tugasanPa.value
+  .filter((x) => (filters.statusTugasan === 'ALL' || x.statusTugasan === filters.statusTugasan)))
+
+const filteredElaun = computed(() => elaunMonthly.value
+  .filter((x) => x.tahun === filters.tahun)
+  .filter((x) => (filters.bulan === 'ALL' ? true : x.month === filters.bulan)))
+
+const filteredPrograms = computed(() => programs.value)
+
+// ===== Summary Cards =====
+const summary = computed(() => {
+  const bilPaAktif = filteredPA.value.filter((x) => x.status === 'Aktif').length
+  const totalPermohonan = filteredPermohonanMonthly.value.reduce((acc, x) => acc + x.baharu + x.pembaharuan, 0)
+  const bilTugasanAktif = filteredTugasan.value.filter((x) => x.statusTugasan !== 'Lengkap').length
+  const bulanIni = (new Date().getMonth() + 1).toString().padStart(2, '0')
+  const elaunBulanIni = filteredElaun.value.find((x) => x.month === bulanIni)
+  const jumlahElaunBulanIni = elaunBulanIni ? elaunBulanIni.jumlahRM : 0
+  return { bilPaAktif, totalPermohonan, bilTugasanAktif, jumlahElaunBulanIni }
+})
+
+const summaryLabelPermohonan = computed(() => {
+  const m = filteredPermohonanMonthly.value
+  const bh = m.reduce((acc, x) => acc + x.baharu, 0)
+  const pb = m.reduce((acc, x) => acc + x.pembaharuan, 0)
+  return `${summary.value.totalPermohonan} (${bh}/${pb})`
+})
+
+// ===== Charts =====
+const ApexChart = shallowRef<any | null>(null)
+
+onMounted(async () => {
+  try {
+    const mod = await import('vue3-apexcharts')
+    ApexChart.value = mod.default
+  } catch (e) {
+    console.warn('vue3-apexcharts tidak dipasang. Papar fallback ringkas.', e)
+  }
+})
+
+const chartMode = ref<'donut' | 'bar'>('donut')
+const chartPAKategori = computed(() => {
+  const kategoriList = ['Kariah', 'Institusi', 'Hospital']
+  const statusList = ['Aktif', 'Tamat', 'Dibatalkan']
+
+  const seriesByStatus = statusList.map((status) => ({
+    name: status,
+    data: kategoriList.map((kat) => filteredPA.value.filter((x) => x.kategori === kat && x.status === status).length),
+  }))
+
+  const donutSeries = kategoriList.map((kat) => filteredPA.value.filter((x) => x.kategori === kat && x.status === 'Aktif').length)
+
+  const options = {
+    chart: { stacked: chartMode.value === 'bar' },
+    labels: kategoriList,
+    xaxis: { categories: kategoriList },
+    legend: { position: 'top' },
+    dataLabels: { enabled: true },
+  }
+
+  return {
+    series: chartMode.value === 'donut' ? donutSeries : seriesByStatus,
+    options,
+  }
+})
+
+const chartPAKategoriDebug = computed(() => ({ donut: chartPAKategori.value.series }))
+
+const chartPermohonan = computed(() => {
+  const cats = filteredPermohonanMonthly.value.map((x) => x.month)
+  const series = [
+    { name: 'Baharu', data: filteredPermohonanMonthly.value.map((x) => x.baharu) },
+    { name: 'Pembaharuan', data: filteredPermohonanMonthly.value.map((x) => x.pembaharuan) },
+  ]
+  const options = { xaxis: { categories: cats }, legend: { position: 'top' } }
+  return { series, options }
+})
+
+const chartStatusPermohonan = computed(() => {
+  const cats = filteredPermohonanByStatus.value.map((x) => x.tahap)
+  const series = [{ name: 'Bilangan', data: filteredPermohonanByStatus.value.map((x) => x.count) }]
+  const options = { xaxis: { categories: cats }, dataLabels: { enabled: true } }
+  return { series, options }
+})
+
+const chartElaun = computed(() => {
+  const cats = filteredElaun.value.map((x) => x.month)
+  const series = [
+    { name: 'Jumlah PA Layak', type: 'column', data: filteredElaun.value.map((x) => x.paLayak) },
+    { name: 'Jumlah Bayaran (RM)', type: 'line', data: filteredElaun.value.map((x) => x.jumlahRM) },
+  ]
+  const options = {
+    xaxis: { categories: cats },
+    stroke: { width: [0, 3] },
+    dataLabels: { enabled: true, enabledOnSeries: [1] },
+    yaxis: [ { title: { text: 'PA Layak' } }, { opposite: true, title: { text: 'RM' } } ],
+    legend: { position: 'top' },
+  }
+  return { series, options }
+})
+
+const programView = ref<'table' | 'bar'>('table')
+function toggleProgramView() { programView.value = programView.value === 'table' ? 'bar' : 'table' }
+const chartProgram = computed(() => {
+  const cats = filteredPrograms.value.map((x) => x.nama)
+  const series = [{ name: '% Kehadiran', data: filteredPrograms.value.map((x) => x.peratusKehadiran) }]
+  const options = { xaxis: { categories: cats }, dataLabels: { enabled: true }, yaxis: { max: 100 } }
+  return { series, options }
+})
+
+// ===== Tables =====
+const tableTugasan = computed(() => filteredTugasan.value)
+const columnsTugasan = [
+  { key: 'namaPA', label: 'Nama PA', sortable: true },
+  { key: 'bilBancian', label: 'Bil. Tugasan (Bancian)', sortable: true },
+  { key: 'bilSemakan', label: 'Bil. Tugasan (Semakan Asnaf)', sortable: true },
+  { key: 'bilPermohonan', label: 'Bil. Tugasan (Permohonan Bantuan)', sortable: true },
+  { key: 'tarikhTerkini', label: 'Tarikh Terkini', sortable: true },
+  { key: 'statusTugasan', label: 'Status Tugasan', sortable: true },
+  { key: 'slaDue', label: 'SLA Due (hari)', sortable: true },
+]
+
+const tableProgram = computed(() => filteredPrograms.value)
+const columnsProgram = [
+  { key: 'nama', label: 'Nama Program', sortable: true },
+  { key: 'tarikh', label: 'Tarikh', sortable: true },
+  { key: 'hadir', label: 'Bil. Hadir', sortable: true },
+  { key: 'peratusKehadiran', label: '% Kehadiran', sortable: true },
+]
+
+// ===== Report (PD-02) =====
+const showReport = ref(false)
+const report = reactive({ format: 'CSV', skop: 'Dashboard', tahap: 'Ringkas' })
+const reportFormatOptions = [ { label: 'CSV', value: 'CSV' }, { label: 'XLSX (stub)', value: 'XLSX' }, { label: 'PDF (stub)', value: 'PDF' } ]
+const reportScopeOptions = [ { label: 'Dashboard', value: 'Dashboard' }, { label: 'Tugasan PA', value: 'Tugasan' }, { label: 'Permohonan', value: 'Permohonan' } ]
+const reportDetailOptions = [ { label: 'Ringkas', value: 'Ringkas' }, { label: 'Terperinci', value: 'Terperinci' } ]
+
+function downloadReport() {
+  const rows = [
+    ['Bil PA Aktif', summary.value.bilPaAktif],
+    ['Bil Permohonan (Total)', summary.value.totalPermohonan],
+    ['Bil Tugasan Aktif', summary.value.bilTugasanAktif],
+    ['Jumlah Elaun Bulan Ini (RM)', summary.value.jumlahElaunBulanIni],
+  ]
+  const csv = 'Metric,Value\n' + rows.map((r) => r.join(',')).join('\n')
+
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `Laporan_BF-PA_${filters.tahun}-${filters.bulan === 'ALL' ? 'ALL' : filters.bulan}.csv`
+  a.click()
+  URL.revokeObjectURL(url)
+  showReport.value = false
+}
+
+// ===== Utils =====
+function formatRM(v: number) {
+  return new Intl.NumberFormat('ms-MY', { style: 'currency', currency: 'MYR' }).format(v)
+}
+function formatDate(iso: string) {
+  const d = new Date(iso)
+  return d.toLocaleDateString('ms-MY', { year: 'numeric', month: 'short', day: '2-digit' })
+}
+function statusVariant(s: string) {
+  switch (s) {
+    case 'Lengkap': return 'success'
+    case 'Gagal': return 'danger'
+    default: return 'warning'
+  }
+}
+function slaClass(days: number | string) {
+  const n = typeof days === 'string' ? parseFloat(days) : days
+  if (n < 0) return 'text-danger-600 font-medium'
+  if (n === 0) return 'text-warning-600 font-medium'
+  return 'text-gray-700'
+}
+const router = useRouter()
+
+function goToJanaLaporan() {
+  router.push('/BF-PA/DA/dashboard/jana-laporan-statistik')
+}
+</script>
+
+<style scoped>
+.fade-enter-active, .fade-leave-active { transition: opacity .15s ease; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+</style>

--- a/pages/BF-PA/DA/dashboard/jana-laporan-elaun/index.vue
+++ b/pages/BF-PA/DA/dashboard/jana-laporan-elaun/index.vue
@@ -1,0 +1,421 @@
+<template>
+  <div class="space-y-4">
+    <!-- Breadcrumb -->
+    <LayoutsBreadcrumb :items="breadcrumb" />
+
+    <!-- ===== 3.1.1 Tajuk / Meta Laporan ===== -->
+    <rs-card>
+      <template #header>
+        <div class="flex items-center justify-between w-full">
+          <div class="flex items-center gap-3">
+            <Icon name="mdi:file-document-outline" />
+            <span class="font-semibold">Laporan Bayaran Elaun Penolong Amil</span>
+          </div>
+          <div class="flex gap-2">
+            <rs-button variant="primary" @click="onPrint">Cetak</rs-button>
+            <rs-button variant="soft" @click="exportXLSX">Excel (XLSX)</rs-button>
+            <rs-button variant="soft" @click="exportCSV">CSV</rs-button>
+          </div>
+        </div>
+      </template>
+      <template #body>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div class="space-y-1">
+            <div><span class="font-medium">Tajuk Laporan:</span>Laporan Bayaran Elaun Penolong Amil</div>
+            <div><span class="font-medium">Organisasi:</span> Lembaga Zakat Selangor</div>
+            <div><span class="font-medium">Klasifikasi:</span> <rs-badge variant="soft">Dalaman</rs-badge></div>
+          </div>
+          <div class="space-y-1">
+            <div><span class="font-medium">Dijana Oleh:</span> {{ generatedBy }}</div>
+            <div><span class="font-medium">Tarikh/Capa Masa Jana:</span> {{ generatedAtLabel }}</div>
+            <div><span class="font-medium">Tempoh:</span> Tahun {{ filters.tahun }}<span v-if="filters.bulan !== 'ALL'">, Bulan {{ filters.bulan }}</span></div>
+          </div>
+          <div class="space-y-1">
+            <div class="font-medium">Ringkasan Penapis</div>
+            <div>Daerah: {{ filters.daerah === 'ALL' ? 'Semua' : filters.daerah }}</div>
+            <div>Kategori PA: {{ filters.kategori === 'ALL' ? 'Semua' : filters.kategori }}</div>
+            <div>Jenis Elaun: {{ filters.jenisElaun === 'ALL' ? 'Semua' : filters.jenisElaun }}</div>
+          </div>
+        </div>
+
+        <!-- Penapis ringkas -->
+        <div class="grid grid-cols-1 md:grid-cols-5 gap-3 mt-4">
+          <FormKit type="select" v-model="filters.tahun" label="Tahun" :options="tahunOptions" />
+          <FormKit type="select" v-model="filters.bulan" label="Bulan" :options="bulanOptions" />
+          <FormKit type="select" v-model="filters.daerah" label="Daerah" :options="daerahOptions" />
+          <FormKit type="select" v-model="filters.kategori" label="Kategori PA" :options="kategoriOptions" />
+          <FormKit type="select" v-model="filters.jenisElaun" label="Jenis Elaun" :options="jenisElaunOptions" />
+        </div>
+      </template>
+    </rs-card>
+
+    <!-- ===== 3.3 Perbezaan Rekod vs Sistem Kewangan ===== -->
+    <div
+      v-if="hasDiscrepancy"
+      class="rounded-xl border border-amber-200 bg-amber-50 p-4 flex items-start gap-3"
+    >
+      <Icon name="mdi:alert-decagram-outline" class="mt-0.5" />
+      <div>
+        <div class="font-semibold">Perbezaan rekod dikesan</div>
+        <div class="text-sm text-amber-800">
+          Jumlah laporan: <b>{{ formatRM(totalJumlahRM) }}</b> ≠ Jumlah sistem kewangan: <b>{{ formatRM(financialSystemTotal) }}</b>
+        </div>
+        <div class="text-sm mt-2">
+          Rujukan batch sistem kewangan:
+          <ul class="list-disc ml-5">
+            <li v-for="(ref, i) in financialBatchRefs" :key="i">{{ ref }}</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== 3.2.2 Grup: Jenis Elaun → Kategori → Daerah (page break setiap Jenis Elaun) ===== -->
+    <div v-for="(byKategori, jenis) in grouped" :key="jenis" class="report-section print-break">
+      <div class="flex items-center justify-between mt-2 mb-1">
+        <div class="text-lg font-semibold flex items-center gap-2">
+          <Icon name="mdi:cash" /> Jenis Elaun: {{ jenis }}
+        </div>
+        <rs-badge variant="soft">Klasifikasi: Dalaman</rs-badge>
+      </div>
+      <div class="text-sm text-gray-600 mb-3">Kumpulan: Kategori → Daerah</div>
+
+      <div v-for="(byDaerah, kategori) in byKategori" :key="kategori" class="mb-8">
+        <div class="font-medium mb-2 flex items-center gap-2">
+          <Icon name="mdi:shield-account-outline" /> Kategori: {{ kategori }}
+        </div>
+
+        <div v-for="(rows, daerah) in byDaerah" :key="daerah" class="mb-6">
+          <div class="mb-2 text-sm text-gray-700 flex items-center gap-2">
+            <Icon name="mdi:map-marker-radius-outline" /> Daerah: {{ daerah }}
+          </div>
+
+          <!-- ===== 3.2.1 Jadual (Read-only) ===== -->
+          <RsTable
+            :data="rows"
+            :columns="columns"
+            :showNoColumn="false"
+            :showSearch="false"
+            :showFilter="false"
+            :options="{ variant: 'default', striped: true, hover: false, borderless: false }"
+            :optionsAdvanced="{ sortable: true, filterable: false, responsive: true, outsideBorder: true }"
+            advanced
+          >
+            <!-- Formatters mengikut URS -->
+            <template #tarikhTransaksi="{ text }">{{ formatDate(text) }}</template>
+            <template #tarikhBayaran="{ text }">{{ formatDate(text) }}</template>
+            <template #amaunUnitRM="{ text }">{{ formatRM(Number(text)) }}</template>
+            <template #jumlahRM="{ text }">{{ formatRM(Number(text)) }}</template>
+            <template #bankAkaun="{ text }">{{ maskBankAccount(text) }}</template>
+            <!-- Status pembayaran: teks biasa (tiada badge) -->
+          </RsTable>
+        </div>
+      </div>
+    </div>
+
+    <!-- Footer / Cetakan -->
+    <div class="bg-white rounded-2xl border p-5 space-y-6">
+      <div class="text-xs text-gray-500">
+        Klasifikasi: Dalaman • Dihasilkan pada {{ generatedAtLabel }} • “Muka surat” dipapar dalam mod cetak.
+      </div>
+    </div>
+
+    <div class="page-footer print-only">Muka surat <span class="page-number"></span> / <span class="total-pages"></span></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * PA-DA-PD-02 (Bayaran Elaun) — Jana Laporan Bayaran Elaun Penolong Amil
+ * - Header meta (tajuk, organisasi, masa jana, dijana oleh, tempoh, ringkasan penapis)
+ * - Jadual read-only dengan kolum & format (MYR, mask akaun, tarikh DD/MM/YYYY)
+ * - Kumpulan: Jenis Elaun → Kategori → Daerah (page-break setiap Jenis Elaun)
+ * - Komponen perbezaan rekod vs sistem kewangan + rujukan batch
+ */
+import { ref, reactive, computed } from 'vue'
+
+defineOptions({ name: 'PA-DA-PD-02-BayaranElaun' })
+
+/* ===== Breadcrumb ===== */
+const breadcrumb = ref([
+  { name: 'Dashboard', type: 'text', path: '/' },
+  { name: 'Laporan Elaun', type: 'text', path: '#' },
+])
+
+/* ===== Filters ===== */
+const filters = reactive({
+  tahun: new Date().getFullYear().toString(),
+  bulan: 'ALL', // 01..12 or ALL
+  daerah: 'ALL',
+  kategori: 'ALL',       // PAK/PAF/PAP/PAK+ / ALL
+  jenisElaun: 'ALL',     // Tetap/Program/Khas / ALL
+})
+
+const tahunOptions = [
+  { label: '2023', value: '2023' },
+  { label: '2024', value: '2024' },
+  { label: '2025', value: '2025' },
+]
+const bulanOptions = [
+  { label: 'Semua', value: 'ALL' },
+  ...Array.from({ length: 12 }, (_, i) => {
+    const m = String(i + 1).padStart(2, '0')
+    return { label: m, value: m }
+  }),
+]
+const daerahOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Gombak', value: 'Gombak' },
+  { label: 'Klang', value: 'Klang' },
+  { label: 'Hulu Langat', value: 'Hulu Langat' },
+  { label: 'Kuala Selangor', value: 'Kuala Selangor' },
+]
+const kategoriOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'PAK', value: 'PAK' },
+  { label: 'PAF', value: 'PAF' },
+  { label: 'PAP', value: 'PAP' },
+  { label: 'PAK+', value: 'PAK+' },
+]
+const jenisElaunOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Tetap', value: 'Tetap' },
+  { label: 'Program', value: 'Program' },
+  { label: 'Khas', value: 'Khas' },
+]
+
+/* ===== Meta ===== */
+const generatedBy = ref('Pengguna Sistem')
+const generatedAt = ref(new Date())
+const generatedAtLabel = computed(() => {
+  return generatedAt.value.toLocaleString('ms-MY', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+    hour: '2-digit', minute: '2-digit', second: '2-digit'
+  })
+})
+
+/* ===== Mock Data ===== */
+type Row = {
+  tarikhTransaksi: string // ISO
+  idPA: string
+  nama: string
+  kategori: 'PAK' | 'PAF' | 'PAP' | 'PAK+'
+  jenisElaun: 'Tetap' | 'Program' | 'Khas'
+  kodBajet: string
+  bilUnit: number
+  amaunUnitRM: number
+  jumlahRM: number
+  statusPembayaran: 'SUDAH DIBAYAR' | 'BELUM DIBAYAR'
+  noBaucarEFT: string
+  tarikhBayaran?: string // ISO
+  bankAkaun: string      // "BANK_NAME | 1234567890"
+  kariahDaerah: string   // "Kariah ABC / Gombak"
+  catatan?: string
+}
+
+const rowsAll = ref<Row[]>([
+  {
+    tarikhTransaksi: '2025-08-31', idPA: 'PA0001', nama: 'Ahmad Karim', kategori: 'PAK',
+    jenisElaun: 'Tetap', kodBajet: 'BJT-1001', bilUnit: 1, amaunUnitRM: 300, jumlahRM: 300,
+    statusPembayaran: 'SUDAH DIBAYAR', noBaucarEFT: 'EFT-2025-00011', tarikhBayaran: '2025-09-05',
+    bankAkaun: 'BIMB | 1234567890', kariahDaerah: 'Al-Hidayah / Gombak', catatan: ''
+  },
+  {
+    tarikhTransaksi: '2025-09-01', idPA: 'PA0002', nama: 'Siti Rahmah', kategori: 'PAF',
+    jenisElaun: 'Program', kodBajet: 'BJT-2203', bilUnit: 3, amaunUnitRM: 60, jumlahRM: 180,
+    statusPembayaran: 'BELUM DIBAYAR', noBaucarEFT: '-', tarikhBayaran: '',
+    bankAkaun: 'Maybank | 876543210', kariahDaerah: 'An-Nur / Gombak', catatan: 'Menunggu kelulusan'
+  },
+  {
+    tarikhTransaksi: '2025-07-20', idPA: 'PA0101', nama: 'Lim Wei', kategori: 'PAP',
+    jenisElaun: 'Khas', kodBajet: 'BJT-9901', bilUnit: 1, amaunUnitRM: 150, jumlahRM: 150,
+    statusPembayaran: 'SUDAH DIBAYAR', noBaucarEFT: 'EFT-2025-00077', tarikhBayaran: '2025-07-20',
+    bankAkaun: 'RHB | 4455667788', kariahDaerah: '— / Klang', catatan: ''
+  },
+  {
+    tarikhTransaksi: '2025-09-03', idPA: 'PA0203', nama: 'Anand', kategori: 'PAK+',
+    jenisElaun: 'Tetap', kodBajet: 'BJT-1001', bilUnit: 1, amaunUnitRM: 220, jumlahRM: 220,
+    statusPembayaran: 'SUDAH DIBAYAR', noBaucarEFT: 'EFT-2025-00045', tarikhBayaran: '2025-09-05',
+    bankAkaun: 'CIMB | 2211335577', kariahDaerah: '— / Hulu Langat', catatan: '—'
+  },
+])
+
+/* ===== Utils (declare BEFORE usage) ===== */
+function formatRM(v: number) {
+  return new Intl.NumberFormat('ms-MY', { style: 'currency', currency: 'MYR' }).format(v || 0)
+}
+function formatDate(iso?: string) {
+  if (!iso) return '-'
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return '-'
+  const dd = String(d.getDate()).padStart(2, '0')
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const yyyy = d.getFullYear()
+  return `${dd}/${mm}/${yyyy}`
+}
+function maskBankAccount(s: string) {
+  if (!s) return ''
+  const [bank, acct] = s.split('|').map(x => x.trim())
+  if (!acct) return bank || s
+  const last4 = acct.slice(-4)
+  return `${bank} | ******${last4}`
+}
+function csvSafe(v: any) {
+  const s = String(v ?? '')
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`
+  }
+  return s
+}
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+/* ===== Filtered ===== */
+const filteredRows = computed(() => {
+  return rowsAll.value.filter(r => {
+    if (filters.daerah !== 'ALL' && !r.kariahDaerah.endsWith(` / ${filters.daerah}`)) return false
+    if (filters.kategori !== 'ALL' && r.kategori !== filters.kategori) return false
+    if (filters.jenisElaun !== 'ALL' && r.jenisElaun !== filters.jenisElaun) return false
+    if (filters.tahun !== 'ALL' && !String(r.tarikhTransaksi).startsWith(filters.tahun)) return false
+    if (filters.bulan !== 'ALL' && String(r.tarikhTransaksi).slice(5, 7) !== filters.bulan) return false
+    return true
+  })
+})
+
+/* ===== Grouped: Jenis Elaun → Kategori → Daerah ===== */
+const grouped = computed(() => {
+  const byJenis: Record<string, Record<string, Record<string, Row[]>>> = {}
+  for (const r of filteredRows.value) {
+    if (!byJenis[r.jenisElaun]) byJenis[r.jenisElaun] = {}
+    if (!byJenis[r.jenisElaun][r.kategori]) byJenis[r.jenisElaun][r.kategori] = {}
+    const daerah = r.kariahDaerah.split('/').pop()?.trim() || '—'
+    if (!byJenis[r.jenisElaun][r.kategori][daerah]) byJenis[r.jenisElaun][r.kategori][daerah] = []
+    byJenis[r.jenisElaun][r.kategori][daerah].push(r)
+  }
+  // keep stable order
+  const jenisOrder = ['Tetap', 'Program', 'Khas']
+  const kategoriOrder = ['PAK', 'PAF', 'PAP', 'PAK+']
+  const sorted: Record<string, Record<string, Record<string, Row[]>>> = {}
+  Object.keys(byJenis).sort((a, b) => jenisOrder.indexOf(a) - jenisOrder.indexOf(b)).forEach(j => {
+    sorted[j] = {}
+    Object.keys(byJenis[j]).sort((a, b) => kategoriOrder.indexOf(a) - kategoriOrder.indexOf(b)).forEach(k => {
+      sorted[j][k] = {}
+      Object.keys(byJenis[j][k]).sort().forEach(d => {
+        sorted[j][k][d] = byJenis[j][k][d]
+      })
+    })
+  })
+  return sorted
+})
+
+/* ===== Totals & Discrepancy (3.3) ===== */
+const totalJumlahRM = computed(() => filteredRows.value.reduce((acc, r) => acc + (r.jumlahRM || 0), 0))
+const financialSystemTotal = ref(850) // mock: jumlah dari sistem kewangan
+const financialBatchRefs = ref<string[]>(['FIN-BATCH-2025-09-05-01', 'FIN-BATCH-2025-09-10-07'])
+const hasDiscrepancy = computed(() => Math.round(totalJumlahRM.value * 100) !== Math.round(financialSystemTotal.value * 100))
+
+/* ===== Table Columns ===== */
+const columns = [
+  { key: 'tarikhTransaksi', label: 'Tarikh Transaksi', sortable: true },
+  { key: 'idPA', label: 'ID_PA', sortable: true },
+  { key: 'nama', label: 'Nama', sortable: true },
+  { key: 'kategori', label: 'Kategori', sortable: true },
+  { key: 'jenisElaun', label: 'Jenis Elaun', sortable: true },
+  { key: 'kodBajet', label: 'Kod Bajet', sortable: true },
+  { key: 'bilUnit', label: 'Bil. Unit', sortable: true },
+  { key: 'amaunUnitRM', label: 'Amaun Unit (RM)', sortable: true },
+  { key: 'jumlahRM', label: 'Jumlah (RM)', sortable: true },
+  { key: 'statusPembayaran', label: 'Status Pembayaran', sortable: true },
+  { key: 'noBaucarEFT', label: 'No. Baucar / EFT Ref', sortable: true },
+  { key: 'tarikhBayaran', label: 'Tarikh Bayaran', sortable: true },
+  { key: 'bankAkaun', label: 'Bank / No. Akaun', sortable: true },
+  { key: 'kariahDaerah', label: 'Kariah/Daerah', sortable: true },
+  { key: 'catatan', label: 'Catatan', sortable: false },
+]
+
+/* ===== Export ===== */
+function rowsFlatForExport() {
+  return filteredRows.value.map(r => ({
+    'Tarikh Transaksi': formatDate(r.tarikhTransaksi),
+    ID_PA: r.idPA,
+    Nama: r.nama,
+    Kategori: r.kategori,
+    'Jenis Elaun': r.jenisElaun,
+    'Kod Bajet': r.kodBajet,
+    'Bil. Unit': r.bilUnit,
+    'Amaun Unit (RM)': r.amaunUnitRM,
+    'Jumlah (RM)': r.jumlahRM,
+    'Status Pembayaran': r.statusPembayaran,
+    'No. Baucar / EFT Ref': r.noBaucarEFT,
+    'Tarikh Bayaran': formatDate(r.tarikhBayaran),
+    'Bank / No. Akaun': maskBankAccount(r.bankAkaun),
+    'Kariah/Daerah': r.kariahDaerah,
+    Catatan: r.catatan ?? ''
+  }))
+}
+
+function exportCSV() {
+  const data = rowsFlatForExport()
+  if (data.length === 0) return
+  const headers = Object.keys(data[0])
+  const csv = [
+    headers.join(','),
+    ...data.map(row => headers.map(h => csvSafe(row[h as keyof typeof row])).join(','))
+  ].join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  downloadBlob(blob, `Laporan_Elaun_PA_${filters.tahun}_${filters.bulan}.csv`)
+}
+
+function exportXLSX() {
+  const data = rowsFlatForExport()
+  // If SheetJS is available globally, use it; else fall back to CSV
+  // @ts-ignore
+  if (window && window.XLSX) {
+    // @ts-ignore
+    const ws = window.XLSX.utils.json_to_sheet(data)
+    // @ts-ignore
+    const wb = window.XLSX.utils.book_new()
+    // @ts-ignore
+    window.XLSX.utils.book_append_sheet(wb, ws, 'Data')
+    // @ts-ignore
+    const wbout = window.XLSX.write(wb, { bookType: 'xlsx', type: 'array' })
+    const blob = new Blob([wbout], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+    downloadBlob(blob, `Laporan_Elaun_PA_${filters.tahun}_${filters.bulan}.xlsx`)
+  } else {
+    exportCSV()
+  }
+}
+
+/* ===== Cetak ===== */
+function onPrint() {
+  window.print()
+}
+</script>
+
+<style scoped>
+/* Page break per Jenis Elaun */
+@media print {
+  .print-break {
+    page-break-before: always;
+  }
+  .print-break:first-of-type {
+    page-break-before: auto;
+  }
+  .print-only { display: block !important; }
+  .page-footer {
+    position: fixed;
+    bottom: 0;
+    left: 0; right: 0;
+    padding: 6px 12px;
+    font-size: 10px;
+    text-align: right;
+  }
+}
+/* Hide footer on screen */
+.print-only { display: none; }
+</style>

--- a/pages/BF-PA/DA/dashboard/jana-laporan-penamatan/index.vue
+++ b/pages/BF-PA/DA/dashboard/jana-laporan-penamatan/index.vue
@@ -1,0 +1,426 @@
+<template>
+  <div class="space-y-4">
+    <!-- Breadcrumb -->
+    <LayoutsBreadcrumb :items="breadcrumb" />
+
+    <!-- ===== 3.1.1 Tajuk / Meta Laporan ===== -->
+    <rs-card>
+      <template #header>
+        <div class="flex items-center justify-between w-full">
+          <div class="flex items-center gap-3">
+            <Icon name="mdi:file-document-outline" />
+            <span class="font-semibold">Laporan Penamatan / Pembaharuan Tempoh Perkhidmatan</span>
+          </div>
+          <div class="flex gap-2">
+            <rs-button variant="primary" @click="onPrint">Cetak</rs-button>
+            <rs-button variant="soft" @click="exportXLSX">Excel (XLSX)</rs-button>
+            <rs-button variant="soft" @click="exportCSV">CSV</rs-button>
+          </div>
+        </div>
+      </template>
+      <template #body>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div class="space-y-1">
+            <div><span class="font-medium">Tajuk Laporan:</span> Penamatan / Pembaharuan Tempoh Perkhidmatan</div>
+            <div><span class="font-medium">Organisasi:</span> Lembaga Zakat Selangor</div>
+            <div><span class="font-medium">Klasifikasi:</span> <rs-badge variant="soft">Dalaman</rs-badge></div>
+          </div>
+          <div class="space-y-1">
+            <div><span class="font-medium">Dijana Oleh:</span> {{ generatedBy }}</div>
+            <div><span class="font-medium">Tarikh/Capa Masa Jana:</span> {{ generatedAtLabel }}</div>
+            <div><span class="font-medium">Tempoh:</span> Tahun {{ filters.tahun }}<span v-if="filters.bulan !== 'ALL'">, Bulan {{ filters.bulan }}</span></div>
+          </div>
+          <div class="space-y-1">
+            <div class="font-medium">Ringkasan Penapis</div>
+            <div>Daerah: {{ filters.daerah === 'ALL' ? 'Semua' : filters.daerah }}</div>
+            <div>Kategori: {{ filters.kategori === 'ALL' ? 'Semua' : filters.kategori }}</div>
+            <div>Tindakan: {{ filters.tindakan === 'ALL' ? 'Semua' : filters.tindakan }}</div>
+          </div>
+        </div>
+
+        <!-- Penapis ringkas -->
+        <div class="grid grid-cols-1 md:grid-cols-6 gap-3 mt-4">
+          <FormKit type="select" v-model="filters.tahun" label="Tahun" :options="tahunOptions" />
+          <FormKit type="select" v-model="filters.bulan" label="Bulan" :options="bulanOptions" />
+          <FormKit type="select" v-model="filters.daerah" label="Daerah" :options="daerahOptions" />
+          <FormKit type="select" v-model="filters.kategori" label="Kategori" :options="kategoriOptions" />
+          <FormKit type="select" v-model="filters.tindakan" label="Tindakan" :options="tindakanOptions" />
+          <div>
+            <label class="block text-sm font-medium mb-1">Tapisan Tarikh</label>
+            <div class="flex items-center gap-3">
+              <label class="flex items-center gap-2 text-sm">
+                <input type="radio" value="TAMAT" v-model="tarikhFilterBy" />
+                Tarikh Tamat
+              </label>
+              <label class="flex items-center gap-2 text-sm">
+                <input type="radio" value="TINDAKAN" v-model="tarikhFilterBy" />
+                Tarikh Tindakan
+              </label>
+            </div>
+          </div>
+        </div>
+      </template>
+    </rs-card>
+
+    <!-- ===== 3.2.2 Kumpul: Daerah → pecahan Tindakan (page break setiap Daerah) ===== -->
+    <div v-for="(byTindakan, daerah) in grouped" :key="daerah" class="report-section print-break">
+      <div class="flex items-center justify-between mt-2 mb-1">
+        <div class="text-lg font-semibold flex items-center gap-2">
+          <Icon name="mdi:map-marker-radius-outline" /> Daerah: {{ daerah }}
+        </div>
+        <rs-badge variant="soft">Klasifikasi: Dalaman</rs-badge>
+      </div>
+      <div class="text-sm text-gray-600 mb-3">Pecahan mengikut Tindakan: Renew / Tamat / Pending</div>
+
+      <div v-for="(rows, tindakan) in byTindakan" :key="tindakan" class="mb-6">
+        <div class="font-medium mb-2 flex items-center gap-2">
+          <Icon name="mdi:shield-refresh-outline" /> Tindakan: {{ tindakan }}
+        </div>
+
+        <!-- ===== 3.2.1 Jadual (Read-only) ===== -->
+        <RsTable
+          :data="rows"
+          :columns="columns"
+          :showNoColumn="false"
+          :showSearch="false"
+          :showFilter="false"
+          :options="{ variant: 'default', striped: true, hover: false, borderless: false }"
+          :optionsAdvanced="{ sortable: true, filterable: false, responsive: true, outsideBorder: true }"
+          advanced
+        >
+          <!-- Formatters ikut URS -->
+          <template #noKP="{ text }">{{ maskNRIC(text) }}</template>
+
+          <template #tarikhMula="{ text }">{{ formatDate(text) }}</template>
+          <template #tarikhTamat="{ text }">{{ formatDate(text) }}</template>
+          <template #tarikhTindakan="{ text }">{{ formatDate(text) }}</template>
+
+          <template #tempohBulan="{ value }">
+            <span>{{ monthDiffFromRow(value) }}</span>
+          </template>
+
+          <!-- Semua status sebagai teks biasa: tindakan, status serah tugas -->
+        </RsTable>
+      </div>
+    </div>
+
+    <!-- Footer / Cetakan -->
+    <div class="bg-white rounded-2xl border p-5 space-y-6">
+      <div class="text-xs text-gray-500">
+        Klasifikasi: Dalaman • Dihasilkan pada {{ generatedAtLabel }} • “Muka surat” dipapar dalam mod cetak.
+      </div>
+    </div>
+
+    <div class="page-footer print-only">Muka surat <span class="page-number"></span> / <span class="total-pages"></span></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * PA-DA-PD-02 — Jana Laporan Penamatan / Pembaharuan Tempoh Perkhidmatan
+ * - Header/meta, filters
+ * - Table columns (read-only) with date mask & NRIC mask
+ * - Grouping: Daerah → Tindakan (Renew/Tamat/Pending) with page break per Daerah
+ * - Tempoh (bulan) = beza antara Tarikh Mula & Tarikh Tamat
+ */
+import { ref, reactive, computed } from 'vue'
+
+defineOptions({ name: 'PA-DA-PD-02-PenamatanPembaharuan' })
+
+/* ===== Breadcrumb ===== */
+const breadcrumb = ref([
+  { name: 'Dashboard', type: 'text', path: '/' },
+  { name: 'Laporan Penamatan/Pembaharuan', type: 'text', path: '#' },
+])
+
+/* ===== Filters ===== */
+const filters = reactive({
+  tahun: new Date().getFullYear().toString(),
+  bulan: 'ALL', // 01..12 or ALL
+  daerah: 'ALL',
+  kategori: 'ALL',         // PAK/PAF/PAP/PAK+ / ALL
+  tindakan: 'ALL',         // Renew/Tamat/Pending / ALL
+})
+const tarikhFilterBy = ref<'TAMAT' | 'TINDAKAN'>('TAMAT')
+
+const tahunOptions = [
+  { label: '2023', value: '2023' },
+  { label: '2024', value: '2024' },
+  { label: '2025', value: '2025' },
+]
+const bulanOptions = [
+  { label: 'Semua', value: 'ALL' },
+  ...Array.from({ length: 12 }, (_, i) => {
+    const m = String(i + 1).padStart(2, '0')
+    return { label: m, value: m }
+  }),
+]
+const daerahOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Gombak', value: 'Gombak' },
+  { label: 'Klang', value: 'Klang' },
+  { label: 'Hulu Langat', value: 'Hulu Langat' },
+  { label: 'Kuala Selangor', value: 'Kuala Selangor' },
+]
+const kategoriOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'PAK', value: 'PAK' },
+  { label: 'PAF', value: 'PAF' },
+  { label: 'PAP', value: 'PAP' },
+  { label: 'PAK+', value: 'PAK+' },
+]
+const tindakanOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Renew', value: 'Renew' },
+  { label: 'Tamat', value: 'Tamat' },
+  { label: 'Pending', value: 'Pending' },
+]
+
+/* ===== Meta ===== */
+const generatedBy = ref('Pengguna Sistem')
+const generatedAt = ref(new Date())
+const generatedAtLabel = computed(() => {
+  return generatedAt.value.toLocaleString('ms-MY', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+    hour: '2-digit', minute: '2-digit', second: '2-digit'
+  })
+})
+
+/* ===== Mock Data ===== */
+type Row = {
+  idPA: string
+  nama: string
+  noKP: string
+  kategori: 'PAK' | 'PAF' | 'PAP' | 'PAK+'
+  kariahDaerah: string   // "Kariah XYZ / Gombak"
+  tarikhMula: string     // ISO
+  tarikhTamat: string    // ISO
+  tindakan: 'Renew' | 'Tamat' | 'Pending'
+  noSurat?: string
+  tarikhTindakan?: string // ISO
+  tempohBulan?: number    // computed for export (optional)
+  sebabPenamatan?: string
+  statusSerahTugas: 'Selesai' | 'Belum'
+  pegawaiPelulus: string
+  catatan?: string
+}
+
+const rowsAll = ref<Row[]>([
+  {
+    idPA: 'PA0001', nama: 'Ahmad Karim', noKP: '880101105555', kategori: 'PAK',
+    kariahDaerah: 'Al-Hidayah / Gombak',
+    tarikhMula: '2025-01-01', tarikhTamat: '2025-12-31',
+    tindakan: 'Renew', noSurat: 'LZS/GOM/REN/2025/001', tarikhTindakan: '2025-12-01',
+    sebabPenamatan: '', statusSerahTugas: 'Selesai', pegawaiPelulus: 'En. Razak', catatan: ''
+  },
+  {
+    idPA: 'PA0002', nama: 'Siti Rahmah', noKP: '900202085432', kategori: 'PAF',
+    kariahDaerah: 'An-Nur / Gombak',
+    tarikhMula: '2024-02-01', tarikhTamat: '2025-01-31',
+    tindakan: 'Tamat', noSurat: 'LZS/GOM/TMT/2025/015', tarikhTindakan: '2025-01-31',
+    sebabPenamatan: 'Kontrak tamat', statusSerahTugas: 'Selesai', pegawaiPelulus: 'Pn. Mariam', catatan: ''
+  },
+  {
+    idPA: 'PA0101', nama: 'Lim Wei', noKP: '870707086543', kategori: 'PAP',
+    kariahDaerah: '— / Klang',
+    tarikhMula: '2024-10-01', tarikhTamat: '2025-09-30',
+    tindakan: 'Pending', noSurat: '', tarikhTindakan: '',
+    sebabPenamatan: '', statusSerahTugas: 'Belum', pegawaiPelulus: 'En. Farid', catatan: 'Menunggu keputusan'
+  },
+  {
+    idPA: 'PA0203', nama: 'Anand', noKP: '950505015432', kategori: 'PAK+',
+    kariahDaerah: '— / Hulu Langat',
+    tarikhMula: '2025-04-01', tarikhTamat: '2025-12-31',
+    tindakan: 'Renew', noSurat: 'LZS/HLG/REN/2025/042', tarikhTindakan: '2025-12-15',
+    sebabPenamatan: '', statusSerahTugas: 'Selesai', pegawaiPelulus: 'Pn. Noraini', catatan: '—'
+  },
+])
+
+/* ===== Utils ===== */
+function maskNRIC(nric: string) {
+  if (!nric) return ''
+  const digits = (nric || '').replace(/\D/g, '')
+  if (digits.length <= 4) return digits
+  const first2 = digits.slice(0, 2)
+  const last4 = digits.slice(-4)
+  return `${first2}******${last4}`
+}
+function formatDate(iso?: string) {
+  if (!iso) return '-'
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return '-'
+  const dd = String(d.getDate()).padStart(2, '0')
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const yyyy = d.getFullYear()
+  return `${dd}/${mm}/${yyyy}`
+}
+function monthDiff(isoStart?: string, isoEnd?: string) {
+  if (!isoStart || !isoEnd) return 0
+  const a = new Date(isoStart)
+  const b = new Date(isoEnd)
+  if (isNaN(a.getTime()) || isNaN(b.getTime())) return 0
+  let months = (b.getFullYear() - a.getFullYear()) * 12 + (b.getMonth() - a.getMonth())
+  if (b.getDate() >= a.getDate()) months += 1
+  return Math.max(0, months)
+}
+function monthDiffFromRow(
+  row: { tarikhMula?: string; tarikhTamat?: string } | any
+) {
+  return monthDiff(row?.tarikhMula, row?.tarikhTamat)
+}
+function csvSafe(v: any) {
+  const s = String(v ?? '')
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`
+  }
+  return s
+}
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+/* ===== Filtered ===== */
+function tarikhUntukTapisan(r: Row) {
+  // ikut pilihan: Tarikh Tamat atau Tarikh Tindakan
+  return tarikhFilterBy.value === 'TINDAKAN' ? (r.tarikhTindakan || r.tarikhTamat) : r.tarikhTamat
+}
+const filteredRows = computed(() => {
+  return rowsAll.value.filter(r => {
+    if (filters.daerah !== 'ALL' && !r.kariahDaerah.endsWith(` / ${filters.daerah}`)) return false
+    if (filters.kategori !== 'ALL' && r.kategori !== filters.kategori) return false
+    if (filters.tindakan !== 'ALL' && r.tindakan !== filters.tindakan) return false
+    const t = tarikhUntukTapisan(r) || ''
+    if (filters.tahun !== 'ALL' && !String(t).startsWith(filters.tahun)) return false
+    if (filters.bulan !== 'ALL' && String(t).slice(5, 7) !== filters.bulan) return false
+    return true
+  })
+})
+
+/* ===== Grouped: Daerah → Tindakan ===== */
+const grouped = computed(() => {
+  const byDaerah: Record<string, Record<string, Row[]>> = {}
+  for (const r of filteredRows.value) {
+    const daerah = (r.kariahDaerah.split('/').pop() || '—').trim()
+    if (!byDaerah[daerah]) byDaerah[daerah] = {}
+    if (!byDaerah[daerah][r.tindakan]) byDaerah[daerah][r.tindakan] = []
+    byDaerah[daerah][r.tindakan].push(r)
+  }
+  // sort tindakan order
+  const tindakanOrder = ['Renew', 'Tamat', 'Pending']
+  const sorted: Record<string, Record<string, Row[]>> = {}
+  Object.keys(byDaerah).sort().forEach(d => {
+    sorted[d] = {}
+    tindakanOrder.forEach(tk => {
+      if (byDaerah[d][tk]) sorted[d][tk] = byDaerah[d][tk]
+    })
+    // any remaining
+    Object.keys(byDaerah[d]).forEach(tk => {
+      if (!sorted[d][tk]) sorted[d][tk] = byDaerah[d][tk]
+    })
+  })
+  return sorted
+})
+
+/* ===== Table Columns ===== */
+const columns = [
+  { key: 'idPA', label: 'ID_PA', sortable: true },
+  { key: 'nama', label: 'Nama', sortable: true },
+  { key: 'noKP', label: 'No. KP', sortable: true },
+  { key: 'kategori', label: 'Kategori', sortable: true },
+  { key: 'kariahDaerah', label: 'Kariah/Daerah', sortable: true },
+  { key: 'tarikhMula', label: 'Tarikh Mula', sortable: true },
+  { key: 'tarikhTamat', label: 'Tarikh Tamat', sortable: true },
+  { key: 'tindakan', label: 'Tindakan', sortable: true },
+  { key: 'noSurat', label: 'No. Surat (Renew/Tamat)', sortable: true },
+  { key: 'tarikhTindakan', label: 'Tarikh Tindakan', sortable: true },
+  { key: 'tempohBulan', label: 'Tempoh (bulan)', sortable: true },
+  { key: 'sebabPenamatan', label: 'Sebab Penamatan', sortable: true },
+  { key: 'statusSerahTugas', label: 'Status Serah Tugas', sortable: true },
+  { key: 'pegawaiPelulus', label: 'Pegawai Pelulus', sortable: true },
+  { key: 'catatan', label: 'Catatan', sortable: false },
+]
+
+/* ===== Export ===== */
+function rowsFlatForExport() {
+  return filteredRows.value.map(r => ({
+    ID_PA: r.idPA,
+    Nama: r.nama,
+    'No. KP': maskNRIC(r.noKP),
+    Kategori: r.kategori,
+    'Kariah/Daerah': r.kariahDaerah,
+    'Tarikh Mula': formatDate(r.tarikhMula),
+    'Tarikh Tamat': formatDate(r.tarikhTamat),
+    Tindakan: r.tindakan,
+    'No. Surat (Renew/Tamat)': r.noSurat ?? '',
+    'Tarikh Tindakan': formatDate(r.tarikhTindakan),
+    'Tempoh (bulan)': monthDiff(r.tarikhMula, r.tarikhTamat),
+    'Sebab Penamatan': r.sebabPenamatan ?? '',
+    'Status Serah Tugas': r.statusSerahTugas,
+    'Pegawai Pelulus': r.pegawaiPelulus,
+    Catatan: r.catatan ?? ''
+  }))
+}
+function exportCSV() {
+  const data = rowsFlatForExport()
+  if (data.length === 0) return
+  const headers = Object.keys(data[0])
+  const csv = [
+    headers.join(','),
+    ...data.map(row => headers.map(h => csvSafe(row[h as keyof typeof row])).join(','))
+  ].join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  downloadBlob(blob, `Laporan_PenamatanPembaharuan_${filters.tahun}_${filters.bulan}.csv`)
+}
+function exportXLSX() {
+  const data = rowsFlatForExport()
+  // If SheetJS is available globally, use it; else fall back to CSV
+  // @ts-ignore
+  if (window && window.XLSX) {
+    // @ts-ignore
+    const ws = window.XLSX.utils.json_to_sheet(data)
+    // @ts-ignore
+    const wb = window.XLSX.utils.book_new()
+    // @ts-ignore
+    window.XLSX.utils.book_append_sheet(wb, ws, 'Data')
+    // @ts-ignore
+    const wbout = window.XLSX.write(wb, { bookType: 'xlsx', type: 'array' })
+    const blob = new Blob([wbout], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+    downloadBlob(blob, `Laporan_PenamatanPembaharuan_${filters.tahun}_${filters.bulan}.xlsx`)
+  } else {
+    exportCSV()
+  }
+}
+
+/* ===== Cetak ===== */
+function onPrint() {
+  window.print()
+}
+</script>
+
+<style scoped>
+/* Page break per Daerah */
+@media print {
+  .print-break {
+    page-break-before: always;
+  }
+  .print-break:first-of-type {
+    page-break-before: auto;
+  }
+  .print-only { display: block !important; }
+  .page-footer {
+    position: fixed;
+    bottom: 0;
+    left: 0; right: 0;
+    padding: 6px 12px;
+    font-size: 10px;
+    text-align: right;
+  }
+}
+/* Hide footer on screen */
+.print-only { display: none; }
+</style>

--- a/pages/BF-PA/DA/dashboard/jana-laporan-pendaftaran/index.vue
+++ b/pages/BF-PA/DA/dashboard/jana-laporan-pendaftaran/index.vue
@@ -1,0 +1,449 @@
+<template>
+  <div class="space-y-4">
+    <!-- Breadcrumb -->
+    <LayoutsBreadcrumb :items="breadcrumb" />
+
+    <!-- ===== 3.1.1 Tajuk / Meta Laporan ===== -->
+    <rs-card>
+      <template #header>
+        <div class="flex items-center justify-between w-full">
+          <div class="flex items-center gap-3">
+            <Icon name="mdi:file-document-outline" />
+            <span class="font-semibold">Laporan Statistik Pendaftaran Penolong Amil</span>
+          </div>
+          <div class="flex gap-2">
+            <rs-button variant="primary" @click="onPrint">Cetak</rs-button>
+            <rs-button variant="soft" @click="exportXLSX">Excel (XLSX)</rs-button>
+            <rs-button variant="soft" @click="exportCSV">CSV</rs-button>
+          </div>
+        </div>
+      </template>
+      <template #body>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div class="space-y-1">
+            <div><span class="font-medium">Tajuk Laporan:</span> Laporan Statistik Pendaftaran Penolong Amil</div>
+            <div><span class="font-medium">Organisasi:</span> Lembaga Zakat Selangor</div>
+            <div><span class="font-medium">Klasifikasi:</span> <rs-badge variant="soft">Dalaman</rs-badge></div>
+          </div>
+          <div class="space-y-1">
+            <div><span class="font-medium">Dijana Oleh:</span> {{ generatedBy }}</div>
+            <div><span class="font-medium">Tarikh/Capa Masa Jana:</span> {{ generatedAtLabel }}</div>
+            <div><span class="font-medium">Tempoh:</span> Tahun {{ filters.tahun }}<span v-if="filters.bulan !== 'ALL'">, Bulan {{ filters.bulan }}</span></div>
+          </div>
+          <div class="space-y-1">
+            <div class="font-medium">Ringkasan Penapis</div>
+            <div>Daerah: {{ filters.daerah === 'ALL' ? 'Semua' : filters.daerah }}</div>
+            <div>Kategori PA: {{ filters.kategori === 'ALL' ? 'Semua' : filters.kategori }}</div>
+          </div>
+        </div>
+
+        <!-- Penapis ringkas (optional) -->
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-3 mt-4">
+          <FormKit type="select" v-model="filters.tahun" label="Tahun" :options="tahunOptions" />
+          <FormKit type="select" v-model="filters.bulan" label="Bulan" :options="bulanOptions" />
+          <FormKit type="select" v-model="filters.daerah" label="Daerah" :options="daerahOptions" />
+          <FormKit type="select" v-model="filters.kategori" label="Kategori PA" :options="kategoriOptions" />
+        </div>
+      </template>
+    </rs-card>
+
+    <!-- ===== 3.2.2 Seksyen Kumpulan: Daerah → Kategori PA (page break setiap Daerah) ===== -->
+    <div v-for="(byKategori, daerah) in grouped" :key="daerah" class="report-section print-break">
+      <div class="flex items-center justify-between mt-2 mb-1">
+        <div class="text-lg font-semibold flex items-center gap-2">
+          <Icon name="mdi:map-marker-radius-outline" /> Daerah: {{ daerah }}
+        </div>
+        <rs-badge variant="soft">Klasifikasi: Dalaman</rs-badge>
+      </div>
+      <div class="text-sm text-gray-600 mb-3">Kumpulan mengikut Kategori PA</div>
+
+      <div v-for="(rows, kategori) in byKategori" :key="kategori" class="mb-6">
+        <div class="font-medium mb-2 flex items-center gap-2">
+          <Icon name="mdi:shield-account-outline" /> Kategori PA: {{ kategori }}
+        </div>
+
+        <!-- ===== 3.2.1 Jadual Utama (Read-only) ===== -->
+        <RsTable
+          :data="rows"
+          :columns="columns"
+          :showNoColumn="false"
+          :showSearch="false"
+          :showFilter="false"
+          :options="{ variant: 'default', striped: true, hover: false, borderless: false }"
+          :optionsAdvanced="{ sortable: true, filterable: false, responsive: true, outsideBorder: true }"
+          advanced
+        >
+          <!-- Formatters per spesifikasi -->
+          <template #noKP="{ text }">{{ maskNRIC(text) }}</template>
+
+          <template #tarikhPermohonan="{ text }">{{ formatDate(text) }}</template>
+          <template #tarikhKelulusan="{ text }">{{ formatDate(text) }}</template>
+          <template #tarikhMulaLantikan="{ text }">{{ formatDate(text) }}</template>
+          <template #tarikhTamatLantikan="{ text }">
+            <span :class="isExpired(text) ? 'text-danger-600 font-semibold' : ''">
+              {{ formatDate(text) }}
+            </span>
+          </template>
+
+          <template #tempohBulan="{ value }">
+            <span>{{ monthDiffFromRow(value) }}</span>
+            </template>
+
+
+          <template #statusPerkhidmatan="{ text }">
+            <rs-badge :variant="statusVariant(text)">{{ text }}</rs-badge>
+          </template>
+        </RsTable>
+      </div>
+    </div>
+
+    <!-- ===== 3.3 Bahagian Tandatangan / Footer ===== -->
+    <div class="bg-white rounded-2xl border p-5 space-y-6">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div>
+          <div class="font-medium mb-3">Disediakan oleh</div>
+          <div class="h-16 border-b"></div>
+          <div class="text-sm mt-2 text-gray-600">Nama & Tarikh</div>
+        </div>
+        <div>
+          <div class="font-medium mb-3">Disemak oleh</div>
+          <div class="h-16 border-b"></div>
+          <div class="text-sm mt-2 text-gray-600">Nama & Tarikh</div>
+        </div>
+        <div>
+          <div class="font-medium mb-3">Diluluskan oleh</div>
+          <div class="h-16 border-b"></div>
+          <div class="text-sm mt-2 text-gray-600">Nama & Tarikh</div>
+        </div>
+      </div>
+      <div class="text-xs text-gray-500">
+        Klasifikasi: Dalaman • Dihasilkan pada {{ generatedAtLabel }} • “Muka surat” akan dipapar dalam mod cetak.
+      </div>
+    </div>
+
+    <!-- Footer print (page x/y) -->
+    <div class="page-footer print-only">Muka surat <span class="page-number"></span> / <span class="total-pages"></span></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * PA-DA-PD-02 (Pendaftaran) — Jana Laporan Statistik Pendaftaran Penolong Amil
+ * - Header meta (tajuk, organisasi, masa jana, dijana oleh, tempoh, ringkasan penapis)
+ * - Jadual read-only dengan kolum & format yang ditetapkan
+ * - Kumpulan: Daerah → Kategori PA (page-break setiap Daerah)
+ * - Footer: Disediakan/Disemak/Diluluskan, muka surat x/y, klasifikasi
+ */
+import { ref, reactive, computed, onMounted } from 'vue'
+
+defineOptions({ name: 'PA-DA-PD-02-Pendaftaran' })
+
+/* ===== Breadcrumb ===== */
+const breadcrumb = ref([
+  { name: 'Dashboard', type: 'text', path: '/' },
+  { name: 'Laporan Pendaftaran ', type: 'text', path: '#' },
+])
+
+/* ===== Filters (for header summary) ===== */
+const filters = reactive({
+  tahun: new Date().getFullYear().toString(),
+  bulan: 'ALL', // 01..12 or ALL
+  daerah: 'ALL',
+  kategori: 'ALL',
+})
+
+const tahunOptions = [
+  { label: '2023', value: '2023' },
+  { label: '2024', value: '2024' },
+  { label: '2025', value: '2025' },
+]
+const bulanOptions = [
+  { label: 'Semua', value: 'ALL' },
+  ...Array.from({ length: 12 }, (_, i) => {
+    const m = String(i + 1).padStart(2, '0')
+    return { label: m, value: m }
+  }),
+]
+const daerahOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Gombak', value: 'Gombak' },
+  { label: 'Klang', value: 'Klang' },
+  { label: 'Hulu Langat', value: 'Hulu Langat' },
+  { label: 'Kuala Selangor', value: 'Kuala Selangor' },
+]
+const kategoriOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'PAK', value: 'PAK' },
+  { label: 'PAF', value: 'PAF' },
+  { label: 'PAP', value: 'PAP' },
+  { label: 'PAK+', value: 'PAK+' },
+]
+
+/* ===== Meta ===== */
+const generatedBy = ref('Pengguna Sistem')
+const generatedAt = ref(new Date())
+const generatedAtLabel = computed(() => {
+  return generatedAt.value.toLocaleString('ms-MY', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+    hour: '2-digit', minute: '2-digit', second: '2-digit'
+  })
+})
+
+/* ===== Mock Data (示例) ===== */
+type Row = {
+  idPA: string
+  nama: string
+  noKP: string
+  kategoriPA: 'PAK' | 'PAF' | 'PAP' | 'PAK+'
+  kariah: string
+  daerah: string
+  tarikhPermohonan: string // ISO
+  tarikhKelulusan: string  // ISO
+  tarikhMulaLantikan: string // ISO
+  tarikhTamatLantikan: string // ISO
+  statusPerkhidmatan: 'AKTIF' | 'TAMAT' | 'DIGANTUNG'
+  pegawaiPenyelia: string
+  noSuratLantikan: string
+  catatan?: string
+}
+
+const rowsAll = ref<Row[]>([
+  {
+    idPA: 'PA0001', nama: 'Ahmad Karim', noKP: '880101105555',
+    kategoriPA: 'PAK', kariah: 'Al-Hidayah', daerah: 'Gombak',
+    tarikhPermohonan: '2024-11-20', tarikhKelulusan: '2024-12-15',
+    tarikhMulaLantikan: '2025-01-01', tarikhTamatLantikan: '2025-12-31',
+    statusPerkhidmatan: 'AKTIF', pegawaiPenyelia: 'En. Razak',
+    noSuratLantikan: 'LZS/GOM/PA/2025/001', catatan: '—'
+  },
+  {
+    idPA: 'PA0002', nama: 'Siti Rahmah', noKP: '900202085432',
+    kategoriPA: 'PAF', kariah: 'An-Nur', daerah: 'Gombak',
+    tarikhPermohonan: '2025-01-05', tarikhKelulusan: '2025-01-20',
+    tarikhMulaLantikan: '2025-02-01', tarikhTamatLantikan: '2025-11-30',
+    statusPerkhidmatan: 'AKTIF', pegawaiPenyelia: 'Pn. Mariam',
+    noSuratLantikan: 'LZS/GOM/PA/2025/015', catatan: ''
+  },
+  {
+    idPA: 'PA0101', nama: 'Lim Wei', noKP: '870707086543',
+    kategoriPA: 'PAP', kariah: '—', daerah: 'Klang',
+    tarikhPermohonan: '2024-10-11', tarikhKelulusan: '2024-12-02',
+    tarikhMulaLantikan: '2025-01-15', tarikhTamatLantikan: '2025-07-31',
+    statusPerkhidmatan: 'TAMAT', pegawaiPenyelia: 'En. Farid',
+    noSuratLantikan: 'LZS/KLG/PA/2025/003', catatan: 'Tamat awal'
+  },
+  {
+    idPA: 'PA0203', nama: 'Anand', noKP: '950505015432',
+    kategoriPA: 'PAK+', kariah: '—', daerah: 'Hulu Langat',
+    tarikhPermohonan: '2025-03-01', tarikhKelulusan: '2025-03-25',
+    tarikhMulaLantikan: '2025-04-01', tarikhTamatLantikan: '2025-12-31',
+    statusPerkhidmatan: 'DIGANTUNG', pegawaiPenyelia: 'Pn. Noraini',
+    noSuratLantikan: 'LZS/HLG/PA/2025/042', catatan: 'Dalam siasatan'
+  },
+])
+
+/* ===== Utils (declared before usage to satisfy TS) ===== */
+function maskNRIC(nric: string) {
+  if (!nric) return ''
+  const digits = (nric || '').replace(/\D/g, '')
+  if (digits.length <= 4) return digits
+  const first2 = digits.slice(0, 2)
+  const last4 = digits.slice(-4)
+  return `${first2}******${last4}`
+}
+function formatDate(iso: string) {
+  if (!iso) return '-'
+  const d = new Date(iso)
+  const dd = String(d.getDate()).padStart(2, '0')
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const yyyy = d.getFullYear()
+  return `${dd}/${mm}/${yyyy}`
+}
+function monthDiff(isoStart: string, isoEnd: string) {
+  if (!isoStart || !isoEnd) return 0
+  const a = new Date(isoStart)
+  const b = new Date(isoEnd)
+  let months = (b.getFullYear() - a.getFullYear()) * 12
+  months += b.getMonth() - a.getMonth()
+  // if end day >= start day, count as full month
+  if (b.getDate() >= a.getDate()) months += 1
+  return Math.max(0, months)
+}
+function isExpired(iso: string) {
+  const today = new Date()
+  const d = new Date(iso)
+  return d < new Date(today.getFullYear(), today.getMonth(), today.getDate())
+}
+function statusVariant(s: string) {
+  if (s === 'AKTIF') return 'success'
+  if (s === 'TAMAT') return 'danger'
+  if (s === 'DIGANTUNG') return 'warning'
+  return 'secondary'
+}
+function monthDiffFromRow(
+  row: { tarikhMulaLantikan?: string; tarikhTamatLantikan?: string } | any
+) {
+  return monthDiff(row?.tarikhMulaLantikan, row?.tarikhTamatLantikan)
+}
+
+
+/* ===== Filtered View ===== */
+const filteredRows = computed(() => {
+  return rowsAll.value.filter(r => {
+    if (filters.daerah !== 'ALL' && r.daerah !== filters.daerah) return false
+    if (filters.kategori !== 'ALL' && r.kategoriPA !== filters.kategori) return false
+    // Tahun/Bulan (optional business rule: guna tarikhMulaLantikan)
+    if (filters.tahun !== 'ALL' && !String(r.tarikhMulaLantikan).startsWith(filters.tahun)) return false
+    if (filters.bulan !== 'ALL' && String(r.tarikhMulaLantikan).slice(5, 7) !== filters.bulan) return false
+    return true
+  })
+})
+
+/* ===== Grouped: Daerah → Kategori PA ===== */
+const grouped = computed(() => {
+  const byDaerah: Record<string, Record<string, Row[]>> = {}
+  for (const r of filteredRows.value) {
+    if (!byDaerah[r.daerah]) byDaerah[r.daerah] = {}
+    if (!byDaerah[r.daerah][r.kategoriPA]) byDaerah[r.daerah][r.kategoriPA] = []
+    byDaerah[r.daerah][r.kategoriPA].push(r)
+  }
+  // Keep kategori order: PAK, PAF, PAP, PAK+
+  const order = ['PAK', 'PAF', 'PAP', 'PAK+']
+  const sorted: Record<string, Record<string, Row[]>> = {}
+  Object.keys(byDaerah).sort().forEach(d => {
+    sorted[d] = {}
+    order.forEach(k => {
+      if (byDaerah[d][k as keyof typeof byDaerah[string]]) {
+        sorted[d][k] = byDaerah[d][k]
+      }
+    })
+    // any remaining categories
+    Object.keys(byDaerah[d]).forEach(k => {
+      if (!sorted[d][k]) sorted[d][k] = byDaerah[d][k]
+    })
+  })
+  return sorted
+})
+
+/* ===== Table Columns (order matches URS) ===== */
+const columns = [
+  { key: 'idPA', label: 'ID_PA', sortable: true },
+  { key: 'nama', label: 'Nama (ikut MyKad)', sortable: true },
+  { key: 'noKP', label: 'No. KP', sortable: true },
+  { key: 'kategoriPA', label: 'Kategori PA', sortable: true },
+  { key: 'kariah', label: 'Kariah', sortable: true },
+  { key: 'daerah', label: 'Daerah', sortable: true },
+  { key: 'tarikhPermohonan', label: 'Tarikh Permohonan', sortable: true },
+  { key: 'tarikhKelulusan', label: 'Tarikh Kelulusan', sortable: true },
+  { key: 'tarikhMulaLantikan', label: 'Tarikh Mula Lantikan', sortable: true },
+  { key: 'tarikhTamatLantikan', label: 'Tarikh Tamat Lantikan', sortable: true },
+  { key: 'tempohBulan', label: 'Tempoh (bulan)', sortable: true },
+  { key: 'statusPerkhidmatan', label: 'Status Perkhidmatan', sortable: true },
+  { key: 'pegawaiPenyelia', label: 'Pegawai Penyelia', sortable: true },
+  { key: 'noSuratLantikan', label: 'No. Surat Lantikan', sortable: true },
+  { key: 'catatan', label: 'Catatan', sortable: false },
+]
+
+/* ===== Export (XLSX/CSV) ===== */
+function rowsFlatForExport() {
+  // flatten from filteredRows; add computed Tempoh (bulan)
+  return filteredRows.value.map(r => ({
+    ID_PA: r.idPA,
+    Nama: r.nama,
+    'No. KP': maskNRIC(r.noKP),
+    'Kategori PA': r.kategoriPA,
+    Kariah: r.kariah,
+    Daerah: r.daerah,
+    'Tarikh Permohonan': formatDate(r.tarikhPermohonan),
+    'Tarikh Kelulusan': formatDate(r.tarikhKelulusan),
+    'Tarikh Mula Lantikan': formatDate(r.tarikhMulaLantikan),
+    'Tarikh Tamat Lantikan': formatDate(r.tarikhTamatLantikan),
+    'Tempoh (bulan)': monthDiff(r.tarikhMulaLantikan, r.tarikhTamatLantikan),
+    'Status Perkhidmatan': r.statusPerkhidmatan,
+    'Pegawai Penyelia': r.pegawaiPenyelia,
+    'No. Surat Lantikan': r.noSuratLantikan,
+    Catatan: r.catatan ?? ''
+  }))
+}
+
+function exportCSV() {
+  const data = rowsFlatForExport()
+  if (data.length === 0) return
+  const headers = Object.keys(data[0])
+  const csv = [
+    headers.join(','),
+    ...data.map(row => headers.map(h => csvSafe(row[h as keyof typeof row])).join(','))
+  ].join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  downloadBlob(blob, `Laporan_Pendaftaran_PA_${filters.tahun}_${filters.bulan}.csv`)
+}
+
+function exportXLSX() {
+  const data = rowsFlatForExport()
+  // If SheetJS is available globally, use it; else fall back to CSV
+  // @ts-ignore
+  if (window && window.XLSX) {
+    // @ts-ignore
+    const ws = window.XLSX.utils.json_to_sheet(data)
+    // @ts-ignore
+    const wb = window.XLSX.utils.book_new()
+    // @ts-ignore
+    window.XLSX.utils.book_append_sheet(wb, ws, 'Data')
+    // @ts-ignore
+    const wbout = window.XLSX.write(wb, { bookType: 'xlsx', type: 'array' })
+    const blob = new Blob([wbout], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+    downloadBlob(blob, `Laporan_Pendaftaran_PA_${filters.tahun}_${filters.bulan}.xlsx`)
+  } else {
+    exportCSV()
+  }
+}
+
+function csvSafe(v: any) {
+  const s = String(v ?? '')
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`
+  }
+  return s
+}
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+/* ===== Cetak ===== */
+function onPrint() {
+  window.print()
+}
+
+/* ===== Print page counters (best-effort) ===== */
+onMounted(() => {
+  // Some browsers support CSS counters; as a fallback, leave placeholders.
+})
+</script>
+
+<style scoped>
+/* Ensure page break for each daerah section when printing */
+@media print {
+  .print-break {
+    page-break-before: always;
+  }
+  .print-break:first-of-type {
+    page-break-before: auto;
+  }
+  .print-only { display: block !important; }
+  .page-footer {
+    position: fixed;
+    bottom: 0;
+    left: 0; right: 0;
+    padding: 6px 12px;
+    font-size: 10px;
+    text-align: right;
+  }
+}
+/* Hide footer on screen */
+.print-only { display: none; }
+</style>

--- a/pages/BF-PA/DA/dashboard/jana-laporan-statistik/index.vue
+++ b/pages/BF-PA/DA/dashboard/jana-laporan-statistik/index.vue
@@ -1,0 +1,868 @@
+<template>
+  <div class="space-y-4">
+    <!-- Breadcrumb -->
+    <LayoutsBreadcrumb :items="breadcrumb" />
+
+    <!-- ===== 3.1.1 Filter Carian ===== -->
+    <rs-card>
+      <template #header>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <Icon name="mdi:tune" />
+            <span class="font-semibold">Laporan Statistik</span>
+          </div>
+          <div class="flex gap-2">
+            <rs-button variant="danger" @click="onReset">Set Semula</rs-button>
+          </div>
+        </div>
+      </template>
+      <template #body>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <FormKit type="select" v-model="filters.kategoriPA" label="Kategori Penolong Amil" :options="kategoriPAOptions" />
+          <FormKit type="select" v-model="filters.lokasiLevel" label="Lokasi (Kariah / Daerah / Institusi)" :options="lokasiLevelOptions" />
+          <FormKit type="select" v-model="filters.lokasi" label="Pilih Lokasi" :options="lokasiOptions" :disabled="filters.lokasiLevel==='ALL'" />
+
+          <FormKit type="select" v-model="filters.statusPA" label="Status PA" :options="statusPAOptions" />
+          <FormKit type="select" v-model="filters.kategoriTugasan" label="Kategori Tugasan" :options="kategoriTugasanOptions" />
+
+          <!-- Tempoh Perkhidmatan -->
+          <div>
+            <label class="block text-sm font-medium mb-1">Tempoh Perkhidmatan</label>
+            <div class="grid grid-cols-2 gap-2">
+              <FormKit type="date" v-model="filters.tarikhMula" label="Mula" />
+              <FormKit type="date" v-model="filters.tarikhTamat" label="Tamat" />
+            </div>
+            <p class="text-xs text-gray-500 mt-1">*Tarikh wajib jika pilih tempoh.</p>
+          </div>
+
+          <FormKit type="select" v-model="filters.jenisElaun" label="Jenis Elaun" :options="jenisElaunOptions" />
+          <FormKit type="select" v-model="filters.statusBayaran" label="Status Bayaran" :options="statusBayaranOptions" />
+          <FormKit type="select" v-model="filters.tahun" label="Tahun" :options="tahunOptions" />
+        </div>
+
+        <!-- Validation -->
+        <div v-if="validation.error" class="mt-3 p-3 rounded-lg bg-red-50 text-red-700 text-sm border border-red-200">
+          <div class="flex items-start gap-2">
+            <Icon name="mdi:alert-circle-outline" />
+            <div>
+              <div class="font-medium">Validasi Gagal</div>
+              <div>{{ validation.message }}</div>
+            </div>
+          </div>
+        </div>
+      </template>
+    </rs-card>
+
+    <!-- ===== 3.2.2 Paparan Statistik (Charts + Summary) ===== -->
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+      <!-- Graf Tugasan -->
+      <rs-card>
+        <template #header>
+          <div class="flex items-center gap-2">
+            <Icon name="mdi:chart-bar" />
+            <span class="font-semibold">Graf Tugasan Mengikut Kategori</span>
+          </div>
+        </template>
+        <template #body>
+          <div v-if="Apex">
+            <component :is="Apex" type="bar" height="280" :series="chartTugasan.series" :options="chartTugasan.options" />
+          </div>
+          <div v-else class="text-sm text-gray-500">Pasang <code>vue3-apexcharts</code> untuk carta.</div>
+        </template>
+      </rs-card>
+
+      <!-- Graf Elaun -->
+      <rs-card>
+        <template #header>
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-2">
+              <Icon name="mdi:chart-donut" />
+              <span class="font-semibold">Graf Elaun Mengikut Jenis</span>
+            </div>
+            <div class="flex gap-2">
+              <rs-button size="sm" :variant="elaunMode==='pie'?'primary':'soft'" @click="elaunMode='pie'">Pai</rs-button>
+              <rs-button size="sm" :variant="elaunMode==='bar'?'primary':'soft'" @click="elaunMode='bar'">Bar</rs-button>
+            </div>
+          </div>
+        </template>
+        <template #body>
+          <div v-if="Apex">
+            <component :is="Apex" :type="elaunMode" height="280" :series="chartElaun.series" :options="chartElaun.options" />
+          </div>
+          <div v-else class="text-sm text-gray-500">Pasang <code>vue3-apexcharts</code> untuk carta.</div>
+        </template>
+      </rs-card>
+
+      <!-- Graf Status PA -->
+      <rs-card>
+        <template #header>
+          <div class="flex items-center gap-2">
+            <Icon name="mdi:chart-pie-outline" />
+            <span class="font-semibold">Graf Status Pendaftaran PA</span>
+          </div>
+        </template>
+        <template #body>
+          <div v-if="Apex">
+            <component :is="Apex" type="donut" height="280" :series="chartStatusPA.series" :options="chartStatusPA.options" />
+          </div>
+          <div v-else class="text-sm text-gray-500">Pasang <code>vue3-apexcharts</code> untuk carta.</div>
+        </template>
+      </rs-card>
+    </div>
+
+    <!-- ===== 3.3 Laporan Tugasan ===== -->
+    <rs-card>
+      <template #header>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <Icon name="mdi:clipboard-text-outline" />
+            <span class="font-semibold">Laporan Tugasan</span>
+          </div>
+          <div class="flex gap-2">
+            <rs-button variant="primary" @click="goToJanaLaporanTugasan">
+              Jana Laporan
+            </rs-button>
+            <rs-button size="sm" variant="soft" @click="exportXLSX('tugasan')">Excel (XLSX)</rs-button>
+            <rs-button size="sm" variant="soft" @click="exportPDF('tugasan')">PDF</rs-button>
+          </div>
+        </div>
+      </template>
+      <template #body>
+        <RsTable
+          :data="laporanTugasan"
+          :columns="columnsTugasan"
+          advanced
+          :showNoColumn="false"
+          :showSearch="true"
+          :showFilter="true"
+          :options="{ variant: 'default', striped: true, hover: true }"
+          :optionsAdvanced="{ sortable: true, filterable: true, responsive: true, outsideBorder: true }"
+        >
+          <template #purataHariSelesai="{ text }">
+            <span :class="Number(text) > 7 ? 'text-warning-600 font-medium' : ''">{{ text }}</span>
+          </template>
+        </RsTable>
+      </template>
+    </rs-card>
+
+    <!-- ===== 3.3.1 Laporan Status Pendaftaran ===== -->
+    <rs-card>
+      <template #header>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <Icon name="mdi:account-badge-outline" />
+            <span class="font-semibold">Laporan Status Pendaftaran</span>
+          </div>
+          <div class="flex gap-2">
+            <rs-button variant="primary" @click="goToJanaLaporan">
+              Jana Laporan
+            </rs-button>
+            <rs-button size="sm" variant="soft" @click="exportXLSX('status')">Excel (XLSX)</rs-button>
+            <rs-button size="sm" variant="soft" @click="exportPDF('status')">PDF</rs-button>
+          </div>
+        </div>
+      </template>
+      <template #body>
+        <RsTable
+          :data="laporanStatus"
+          :columns="columnsStatus"
+          advanced
+          :showNoColumn="false"
+          :showSearch="true"
+          :showFilter="true"
+          :options="{ variant: 'default', striped: true, hover: true }"
+          :optionsAdvanced="{ sortable: true, filterable: true, responsive: true, outsideBorder: true }"
+        >
+          <template #tarikhTamatPerkhidmatan="{ text }">
+            <span :class="isExpired(text) ? 'text-danger-600 font-semibold' : ''">
+              {{ formatDate(text) }}
+            </span>
+          </template>
+          <template #statusPA="{ text }">
+            <rs-badge :variant="statusBadge(text)">{{ text }}</rs-badge>
+          </template>
+        </RsTable>
+      </template>
+    </rs-card>
+
+    <!-- ===== NEW: Laporan Penamatan / Pembaharuan ===== -->
+    <rs-card>
+      <template #header>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <Icon name="mdi:calendar-check" />
+            <span class="font-semibold">Laporan Penamatan / Pembaharuan</span>
+          </div>
+          <div class="flex gap-2">
+            <rs-button variant="primary" @click="goToJanaLaporanPenamatan">
+              Jana Laporan
+            </rs-button>
+            <rs-button size="sm" variant="soft" @click="exportXLSX('status')">Excel (XLSX)</rs-button>
+            <rs-button size="sm" variant="soft" @click="exportPDF('status')">PDF</rs-button>
+          </div>
+        </div>
+      </template>
+      <template #body>
+        <RsTable
+          :data="laporanPenamatan"
+          :columns="columnsPenamatan"
+          advanced
+          :showNoColumn="false"
+          :showSearch="true"
+          :showFilter="true"
+          :options="{ variant: 'default', striped: true, hover: true }"
+          :optionsAdvanced="{ sortable: true, filterable: true, responsive: true, outsideBorder: true }"
+        >
+          <template #noKP="{ text }">{{ maskNRIC(text) }}</template>
+          <template #tarikhMula="{ text }">{{ formatDate(text) }}</template>
+          <template #tarikhTamat="{ text }">{{ formatDate(text) }}</template>
+          <template #tarikhTindakan="{ text }">{{ formatDate(text) }}</template>
+          <template #tempohBulan="{ text }">{{ text }}</template>
+        </RsTable>
+      </template>
+    </rs-card>
+
+    <!-- ===== 3.3.2 Laporan Elaun ===== -->
+    <rs-card>
+      <template #header>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <Icon name="mdi:cash-multiple" />
+            <span class="font-semibold">Laporan Elaun</span>
+          </div>
+          <div class="flex gap-2">
+            <rs-button variant="primary" @click="goToJanaLaporanElaun">
+              Jana Laporan
+            </rs-button>
+            <rs-button size="sm" variant="soft" @click="exportXLSX('elaun')">Excel (XLSX)</rs-button>
+            <rs-button size="sm" variant="soft" @click="exportPDF('elaun')">PDF</rs-button>
+          </div>
+        </div>
+      </template>
+      <template #body>
+        <RsTable
+          :data="laporanElaun"
+          :columns="columnsElaun"
+          advanced
+          :showNoColumn="false"
+          :showSearch="true"
+          :showFilter="true"
+          :options="{ variant: 'default', striped: true, hover: true }"
+          :optionsAdvanced="{ sortable: true, filterable: true, responsive: true, outsideBorder: true }"
+        >
+          <template #tarikhBayaran="{ text }">{{ formatDate(text) }}</template>
+          <template #jumlahElaun="{ text }">{{ formatRM(Number(text)) }}</template>
+          <template #statusBayaran="{ text }">
+            <rs-badge :variant="bayaranBadge(text)">{{ text }}</rs-badge>
+          </template>
+        </RsTable>
+      </template>
+    </rs-card>
+
+    <!-- Click-through modal: individuals under a bar -->
+    <transition name="fade">
+      <div v-if="modal.open" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+        <div class="bg-white rounded-2xl shadow-xl w-full max-w-3xl">
+          <div class="px-6 py-4 border-b flex items-center justify-between">
+            <div class="font-semibold flex items-center gap-2">
+              <Icon name="mdi:account-group" /> Individu — {{ modal.title }}
+            </div>
+            <button class="text-gray-500 hover:text-gray-700" @click="modal.open=false">
+              <Icon name="mdi:close" />
+            </button>
+          </div>
+          <div class="p-6">
+            <RsTable
+              :data="modal.rows"
+              :columns="modalColumns"
+              :options="{ variant: 'default', striped: true, hover: true }"
+              :optionsAdvanced="{ sortable: true, filterable: true, responsive: true }"
+              advanced
+            />
+          </div>
+          <div class="px-6 py-4 border-t flex items-center justify-end gap-2">
+            <rs-button variant="primary" @click="exportCSVRows(modal.rows, 'individu.csv')">Muat Turun CSV</rs-button>
+            <rs-button variant="soft" @click="modal.open=false">Tutup</rs-button>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, computed, shallowRef, onMounted, watch } from 'vue'
+import { useRouter } from 'vue-router'
+
+defineOptions({ name: 'PA-DA-PD-02-Index' })
+
+/* ================== Meta / Breadcrumb ================== */
+const breadcrumb = ref([
+  { name: 'Dashboard', type: 'text', path: '/' },
+  { name: 'Laporan Statistik', type: 'text', path: '#' },
+])
+
+/* ================== Filters & Options ================== */
+const todayISO = new Date().toISOString().slice(0, 10)
+
+const filters = reactive({
+  kategoriPA: 'ALL',
+  lokasiLevel: 'ALL', // ALL | KARIAH | DAERAH | INSTITUSI
+  lokasi: 'ALL',
+  statusPA: 'ALL', // Aktif / Tidak Aktif / Tamat Tempoh / ALL
+  kategoriTugasan: 'ALL', // Bancian / Siasatan / Asnaf Review / ALL
+  tarikhMula: '', // YYYY-MM-DD
+  tarikhTamat: '', // YYYY-MM-DD
+  jenisElaun: 'ALL',
+  statusBayaran: 'ALL', // Lulus / Pending / Ditolak / ALL
+  tahun: new Date().getFullYear().toString(),
+})
+
+const kategoriPAOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Kariah', value: 'KARIAH' },
+  { label: 'Institusi', value: 'INSTITUSI' },
+  { label: 'Hospital', value: 'HOSPITAL' },
+]
+const lokasiLevelOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Kariah', value: 'KARIAH' },
+  { label: 'Daerah', value: 'DAERAH' },
+  { label: 'Institusi', value: 'INSTITUSI' },
+]
+const lokasiOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Kariah Al-Hidayah', value: 'KARIAH:Al-Hidayah' },
+  { label: 'Kariah An-Nur', value: 'KARIAH:An-Nur' },
+  { label: 'Daerah Gombak', value: 'DAERAH:Gombak' },
+  { label: 'Daerah Klang', value: 'DAERAH:Klang' },
+  { label: 'Institusi Hospital Selayang', value: 'INSTITUSI:Hospital Selayang' },
+  { label: 'Institusi UIAM', value: 'INSTITUSI:UIAM' },
+]
+const statusPAOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Aktif', value: 'Aktif' },
+  { label: 'Tidak Aktif', value: 'Tidak Aktif' },
+  { label: 'Tamat Tempoh', value: 'Tamat Tempoh' },
+]
+const kategoriTugasanOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Bancian', value: 'Bancian' },
+  { label: 'Siasatan', value: 'Siasatan' },
+  { label: 'Asnaf Review', value: 'Asnaf Review' },
+]
+const jenisElaunOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Tetap', value: 'Tetap' },
+  { label: 'Program', value: 'Program' },
+  { label: 'Khas', value: 'Khas' },
+]
+const statusBayaranOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Lulus', value: 'Lulus' },
+  { label: 'Pending', value: 'Pending' },
+  { label: 'Ditolak', value: 'Ditolak' },
+]
+const tahunOptions = [
+  { label: '2023', value: '2023' },
+  { label: '2024', value: '2024' },
+  { label: '2025', value: '2025' },
+]
+
+/* ================== Validation ================== */
+const validation = reactive({ error: false, message: '' })
+
+function validateBeforeGenerate(): boolean {
+  validation.error = false
+  validation.message = ''
+  const hasDateOne = !!filters.tarikhMula || !!filters.tarikhTamat
+  if (hasDateOne && !(filters.tarikhMula && filters.tarikhTamat)) {
+    validation.error = true
+    validation.message = 'Sila isi kedua-dua Tarikh Mula dan Tarikh Tamat untuk tempoh perkhidmatan.'
+  }
+  if (filters.tarikhMula && filters.tarikhTamat && filters.tarikhMula > filters.tarikhTamat) {
+    validation.error = true
+    validation.message = 'Tarikh Mula tidak boleh melebihi Tarikh Tamat.'
+  }
+  return !validation.error
+}
+
+function onGenerate() {
+  if (!validateBeforeGenerate()) return
+  refreshNonce()
+}
+
+function onReset() {
+  filters.kategoriPA = 'ALL'
+  filters.lokasiLevel = 'ALL'
+  filters.lokasi = 'ALL'
+  filters.statusPA = 'ALL'
+  filters.kategoriTugasan = 'ALL'
+  filters.tarikhMula = ''
+  filters.tarikhTamat = ''
+  filters.jenisElaun = 'ALL'
+  filters.statusBayaran = 'ALL'
+  filters.tahun = new Date().getFullYear().toString()
+  validation.error = false
+  validation.message = ''
+  refreshNonce()
+}
+
+/* ================== Mock Data ================== */
+const nonce = ref(0)
+function refreshNonce() { nonce.value++ }
+
+const dataIndividu = ref([
+  { nama: 'Ahmad Karim', kategoriPA: 'KARIAH', lokasi: 'KARIAH:Al-Hidayah', statusPA: 'Aktif', tugasan: 'Bancian', jumlahDiambil: 8, jumlahSelesai: 6, purataHariSelesai: 5, tarikhMula: '2025-01-10', tarikhTamat: '2025-12-31', jenisElaun: 'Tetap', statusBayaran: 'Lulus', tarikhBayaran: '2025-08-05', jumlahElaun: 300 },
+  { nama: 'Siti Rahmah', kategoriPA: 'INSTITUSI', lokasi: 'INSTITUSI:UIAM', statusPA: 'Aktif', tugasan: 'Siasatan', jumlahDiambil: 5, jumlahSelesai: 5, purataHariSelesai: 4, tarikhMula: '2025-03-01', tarikhTamat: '2025-12-31', jenisElaun: 'Program', statusBayaran: 'Pending', tarikhBayaran: '2025-09-01', jumlahElaun: 180 },
+  { nama: 'Lim Wei', kategoriPA: 'HOSPITAL', lokasi: 'INSTITUSI:Hospital Selayang', statusPA: 'Tamat Tempoh', tugasan: 'Asnaf Review', jumlahDiambil: 4, jumlahSelesai: 3, purataHariSelesai: 9, tarikhMula: '2024-01-01', tarikhTamat: '2025-07-31', jenisElaun: 'Khas', statusBayaran: 'Ditolak', tarikhBayaran: '2025-07-20', jumlahElaun: 150 },
+  { nama: 'Anand', kategoriPA: 'KARIAH', lokasi: 'KARIAH:An-Nur', statusPA: 'Tidak Aktif', tugasan: 'Bancian', jumlahDiambil: 3, jumlahSelesai: 2, purataHariSelesai: 8, tarikhMula: '2025-02-10', tarikhTamat: '2025-12-31', jenisElaun: 'Tetap', statusBayaran: 'Lulus', tarikhBayaran: '2025-08-25', jumlahElaun: 220 },
+  { nama: 'Zahra', kategoriPA: 'KARIAH', lokasi: 'DAERAH:Gombak', statusPA: 'Aktif', tugasan: 'Siasatan', jumlahDiambil: 6, jumlahSelesai: 5, purataHariSelesai: 6, tarikhMula: '2025-05-01', tarikhTamat: '2025-12-31', jenisElaun: 'Program', statusBayaran: 'Lulus', tarikhBayaran: '2025-09-10', jumlahElaun: 210 },
+  { nama: 'Banu', kategoriPA: 'INSTITUSI', lokasi: 'DAERAH:Klang', statusPA: 'Aktif', tugasan: 'Asnaf Review', jumlahDiambil: 7, jumlahSelesai: 7, purataHariSelesai: 3, tarikhMula: '2025-04-15', tarikhTamat: '2025-12-31', jenisElaun: 'Program', statusBayaran: 'Pending', tarikhBayaran: '2025-09-05', jumlahElaun: 260 },
+])
+
+/* ===== NEW mock for Penamatan / Pembaharuan table ===== */
+type PenamatanRow = {
+  idPA: string
+  nama: string
+  noKP: string
+  kategori: 'PAK' | 'PAF' | 'PAP' | 'PAK+'
+  kariahDaerah: string   // "Kariah XYZ / Gombak"
+  tarikhMula: string     // ISO
+  tarikhTamat: string    // ISO
+  tindakan: 'Renew' | 'Tamat' | 'Pending'
+  noSurat?: string
+  tarikhTindakan?: string // ISO
+  sebabPenamatan?: string
+  statusSerahTugas: 'Selesai' | 'Belum'
+  pegawaiPelulus: string
+  catatan?: string
+}
+
+const dataPenamatan = ref<PenamatanRow[]>([
+  {
+    idPA: 'PA0001', nama: 'Ahmad Karim', noKP: '880101105555', kategori: 'PAK',
+    kariahDaerah: 'Al-Hidayah / Gombak', tarikhMula: '2025-01-01', tarikhTamat: '2025-12-31',
+    tindakan: 'Renew', noSurat: 'LZS/GOM/REN/2025/001', tarikhTindakan: '2025-12-01',
+    sebabPenamatan: '', statusSerahTugas: 'Selesai', pegawaiPelulus: 'En. Razak', catatan: ''
+  },
+  {
+    idPA: 'PA0002', nama: 'Siti Rahmah', noKP: '900202085432', kategori: 'PAF',
+    kariahDaerah: 'An-Nur / Gombak', tarikhMula: '2024-02-01', tarikhTamat: '2025-01-31',
+    tindakan: 'Tamat', noSurat: 'LZS/GOM/TMT/2025/015', tarikhTindakan: '2025-01-31',
+    sebabPenamatan: 'Kontrak tamat', statusSerahTugas: 'Selesai', pegawaiPelulus: 'Pn. Mariam', catatan: ''
+  },
+  {
+    idPA: 'PA0101', nama: 'Lim Wei', noKP: '870707086543', kategori: 'PAP',
+    kariahDaerah: '— / Klang', tarikhMula: '2024-10-01', tarikhTamat: '2025-09-30',
+    tindakan: 'Pending', noSurat: '', tarikhTindakan: '',
+    sebabPenamatan: '', statusSerahTugas: 'Belum', pegawaiPelulus: 'En. Farid', catatan: 'Menunggu keputusan'
+  },
+  {
+    idPA: 'PA0203', nama: 'Anand', noKP: '950505015432', kategori: 'PAK+',
+    kariahDaerah: '— / Hulu Langat', tarikhMula: '2025-04-01', tarikhTamat: '2025-12-31',
+    tindakan: 'Renew', noSurat: 'LZS/HLG/REN/2025/042', tarikhTindakan: '2025-12-15',
+    sebabPenamatan: '', statusSerahTugas: 'Selesai', pegawaiPelulus: 'Pn. Noraini', catatan: '—'
+  },
+])
+
+/* ================== Utils (declare BEFORE usage) ================== */
+function formatRM(v: number) {
+  return new Intl.NumberFormat('ms-MY', { style: 'currency', currency: 'MYR' }).format(v)
+}
+function isExpired(iso: string) {
+  return new Date(iso) < new Date(todayISO)
+}
+function statusBadge(s: string) {
+  if (s === 'Aktif') return 'success'
+  if (s === 'Tamat Tempoh') return 'danger'
+  return 'warning'
+}
+function bayaranBadge(s: string) {
+  if (s === 'Lulus') return 'success'
+  if (s === 'Pending') return 'warning'
+  return 'danger'
+}
+function groupSum(rows: any[], byKey: string, sumKey: string) {
+  return rows.reduce((acc: Record<string, number>, r) => {
+    const k = r[byKey] ?? 'Lain-lain'
+    acc[k] = (acc[k] || 0) + Number(r[sumKey] || 0)
+    return acc
+  }, {})
+}
+function exportCSVRows(rows: any[], filename = 'data.csv') {
+  if (!rows || rows.length === 0) {
+    const blob = new Blob(['(tiada data)'], { type: 'text/plain;charset=utf-8;' })
+    downloadBlob(blob, filename)
+    return
+  }
+  const headers = Object.keys(rows[0])
+  const lines = [headers.join(',')]
+  rows.forEach((r) => {
+    lines.push(headers.map((h) => csvSafe(r[h])).join(','))
+  })
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' })
+  downloadBlob(blob, filename)
+}
+function csvSafe(v: any) {
+  const s = String(v ?? '')
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`
+  }
+  return s
+}
+function jsonToHTMLTable(rows: any[]) {
+  if (!rows || rows.length === 0) return '<p>(tiada data)</p>'
+  const headers = Object.keys(rows[0])
+  const thead = `<tr>${headers.map((h) => `<th>${h}</th>`).join('')}</tr>`
+  const tbody = rows.map((r) =>
+    `<tr>${headers.map((h) => `<td>${r[h] ?? ''}</td>`).join('')}</tr>`
+  ).join('')
+  return `<table><thead>${thead}</thead><tbody>${tbody}</tbody></table>`
+}
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+function formatDate(iso?: string) {
+  if (!iso) return '-'
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return '-'
+  const dd = String(d.getDate()).padStart(2, '0')
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const yyyy = d.getFullYear()
+  return `${dd}/${mm}/${yyyy}`
+}
+function maskNRIC(nric: string) {
+  if (!nric) return ''
+  const digits = (nric || '').replace(/\D/g, '')
+  if (digits.length <= 4) return digits
+  const first2 = digits.slice(0, 2)
+  const last4 = digits.slice(-4)
+  return `${first2}******${last4}`
+}
+function monthDiff(isoStart?: string, isoEnd?: string) {
+  if (!isoStart || !isoEnd) return 0
+  const a = new Date(isoStart)
+  const b = new Date(isoEnd)
+  if (isNaN(a.getTime()) || isNaN(b.getTime())) return 0
+  let months = (b.getFullYear() - a.getFullYear()) * 12 + (b.getMonth() - a.getMonth())
+  if (b.getDate() >= a.getDate()) months += 1
+  return Math.max(0, months)
+}
+
+/* ================== Filter Pipeline (AND) ================== */
+const filteredRows = computed(() => {
+  const rows = dataIndividu.value
+  return rows.filter((r) => {
+    if (filters.kategoriPA !== 'ALL' && r.kategoriPA !== filters.kategoriPA) return false
+    if (filters.lokasiLevel !== 'ALL') {
+      if (!r.lokasi.startsWith(filters.lokasiLevel + ':')) return false
+    }
+    if (filters.lokasi !== 'ALL' && r.lokasi !== filters.lokasi) return false
+    if (filters.statusPA !== 'ALL' && r.statusPA !== filters.statusPA) return false
+    if (filters.kategoriTugasan !== 'ALL' && r.tugasan !== filters.kategoriTugasan) return false
+    if (filters.jenisElaun !== 'ALL' && r.jenisElaun !== filters.jenisElaun) return false
+    if (filters.statusBayaran !== 'ALL' && r.statusBayaran !== filters.statusBayaran) return false
+    if (filters.tahun && !String(r.tarikhMula).startsWith(filters.tahun) && !String(r.tarikhTamat).startsWith(filters.tahun)) return false
+
+    if (filters.tarikhMula && filters.tarikhTamat) {
+      if (r.tarikhMula > filters.tarikhTamat || r.tarikhTamat < filters.tarikhMula) return false
+    }
+    return true
+  })
+})
+
+/* ===== Filter for Penamatan Table (use tarikhTamat / tarikhTindakan year, and by daerah/kategori) ===== */
+const filteredPenamatan = computed(() => {
+  return dataPenamatan.value.filter((r) => {
+    // year filter by either tarikhTindakan or tarikhTamat
+    const t = r.tarikhTindakan || r.tarikhTamat
+    if (filters.tahun !== 'ALL' && (!t || !String(t).startsWith(filters.tahun))) return false
+
+    // lokasiLevel -> check suffix of daerah in "Kariah / Daerah"
+    if (filters.lokasiLevel === 'DAERAH' && filters.lokasi !== 'ALL') {
+      const daerah = (r.kariahDaerah.split('/').pop() || '').trim()
+      const expected = filters.lokasi.replace('DAERAH:', '')
+      if (daerah !== expected) return false
+    }
+
+    if (filters.kategoriPA !== 'ALL') {
+      // map to generic categories if needed; here we treat ALL as pass
+      // (kategori in this dataset is detailed PAK/PAF/PAP/PAK+; skip strict map)
+    }
+
+    return true
+  })
+})
+
+/* ================== Charts ================== */
+const Apex = shallowRef<any | null>(null)
+onMounted(async () => {
+  try {
+    const mod = await import('vue3-apexcharts')
+    Apex.value = mod.default
+  } catch {
+    // noop – fallback text will render
+  }
+})
+
+const elaunMode = ref<'pie' | 'bar'>('pie')
+
+const chartTugasan = computed(() => {
+  const cats = ['Bancian', 'Siasatan', 'Asnaf Review']
+  const counts = cats.map((c) => filteredRows.value.filter((r) => r.tugasan === c).length)
+  return {
+    series: [{ name: 'Bilangan Tugasan (Individu)', data: counts }],
+    options: {
+      xaxis: { categories: cats },
+      dataLabels: { enabled: true },
+      chart: {
+        events: {
+          dataPointSelection: (_e: any, _ctx: any, config: any) => {
+            const kategori = cats[config.dataPointIndex]
+            openModalIndividu(`Tugasan: ${kategori}`, filteredRows.value.filter((r) => r.tugasan === kategori))
+          },
+        },
+      },
+      tooltip: { y: { formatter: (v: number) => `${v} individu` } },
+    },
+  }
+})
+
+const chartElaun = computed(() => {
+  const sums = groupSum(filteredRows.value, 'jenisElaun', 'jumlahElaun')
+  const labels = Object.keys(sums)
+  const data = Object.values(sums)
+  return {
+    series: elaunMode.value === 'pie' ? data : [{ name: 'Jumlah Elaun (RM)', data }],
+    options: {
+      labels,
+      xaxis: { categories: labels },
+      dataLabels: { enabled: true },
+      tooltip: { y: { formatter: (v: number) => formatRM(v) } },
+    },
+  }
+})
+
+const chartStatusPA = computed(() => {
+  const cats = ['Aktif', 'Tidak Aktif', 'Tamat Tempoh']
+  const counts = cats.map((c) => filteredRows.value.filter((r) => r.statusPA === c).length)
+  return {
+    series: counts,
+    options: {
+      labels: cats,
+      dataLabels: { enabled: true },
+      legend: { position: 'bottom' },
+      tooltip: { y: { formatter: (v: number) => `${v} individu` } },
+    },
+  }
+})
+
+/* ================== Tables (existing) ================== */
+const laporanTugasan = computed(() =>
+  filteredRows.value.map((r) => ({
+    nama: r.nama,
+    jumlahTugasanDiambil: r.jumlahDiambil,
+    jumlahTugasanSelesai: r.jumlahSelesai,
+    kategoriTugasan: r.tugasan,
+    lokasi: r.lokasi.replace(':', ' — '),
+    purataHariSelesai: r.purataHariSelesai,
+  }))
+)
+const columnsTugasan = [
+  { key: 'nama', label: 'Nama Penolong Amil' },
+  { key: 'jumlahTugasanDiambil', label: 'Jumlah Tugasan Diambil' },
+  { key: 'jumlahTugasanSelesai', label: 'Jumlah Tugasan Selesai' },
+  { key: 'kategoriTugasan', label: 'Kategori Tugasan' },
+  { key: 'lokasi', label: 'Lokasi' },
+  { key: 'purataHariSelesai', label: 'Purata Hari Selesai' },
+]
+
+const laporanStatus = computed(() =>
+  filteredRows.value.map((r) => ({
+    nama: r.nama,
+    statusPA: r.statusPA,
+    tarikhTamatPerkhidmatan: r.tarikhTamat,
+    lokasi: r.lokasi.replace(':', ' — '),
+    kategoriPA: r.kategoriPA,
+  }))
+)
+const columnsStatus = [
+  { key: 'nama', label: 'Nama Penolong Amil' },
+  { key: 'statusPA', label: 'Status' },
+  { key: 'tarikhTamatPerkhidmatan', label: 'Tarikh Tamat Perkhidmatan' },
+  { key: 'lokasi', label: 'Kariah / Daerah / Institusi' },
+  { key: 'kategoriPA', label: 'Kategori PA' },
+]
+
+const laporanElaun = computed(() =>
+  filteredRows.value.map((r) => ({
+    nama: r.nama,
+    jenisElaun: r.jenisElaun,
+    tarikhBayaran: r.tarikhBayaran,
+    jumlahElaun: r.jumlahElaun,
+    statusBayaran: r.statusBayaran,
+    jenisTugasan: r.tugasan,
+  }))
+)
+const columnsElaun = [
+  { key: 'nama', label: 'Nama Penolong Amil' },
+  { key: 'jenisElaun', label: 'Jenis Elaun' },
+  { key: 'tarikhBayaran', label: 'Tarikh Bayaran' },
+  { key: 'jumlahElaun', label: 'Jumlah Elaun (RM)' },
+  { key: 'statusBayaran', label: 'Status Bayaran' },
+  { key: 'jenisTugasan', label: 'Jenis Tugasan' },
+]
+
+/* ================== NEW: Laporan Penamatan Table ================== */
+const laporanPenamatan = computed(() =>
+  filteredPenamatan.value.map((r) => ({
+    idPA: r.idPA,
+    nama: r.nama,
+    noKP: r.noKP,
+    kategori: r.kategori,
+    kariahDaerah: r.kariahDaerah,
+    tarikhMula: r.tarikhMula,
+    tarikhTamat: r.tarikhTamat,
+    tindakan: r.tindakan,
+    noSurat: r.noSurat || '',
+    tarikhTindakan: r.tarikhTindakan || '',
+    tempohBulan: monthDiff(r.tarikhMula, r.tarikhTamat),
+    sebabPenamatan: r.sebabPenamatan || '',
+    statusSerahTugas: r.statusSerahTugas,
+    pegawaiPelulus: r.pegawaiPelulus,
+    catatan: r.catatan || '',
+  }))
+)
+
+const columnsPenamatan = [
+  { key: 'idPA', label: 'ID_PA', sortable: true },
+  { key: 'nama', label: 'Nama', sortable: true },
+  { key: 'noKP', label: 'No. KP', sortable: true },
+  { key: 'kategori', label: 'Kategori', sortable: true },
+  { key: 'kariahDaerah', label: 'Kariah/Daerah', sortable: true },
+  { key: 'tarikhMula', label: 'Tarikh Mula', sortable: true },
+  { key: 'tarikhTamat', label: 'Tarikh Tamat', sortable: true },
+  { key: 'tindakan', label: 'Tindakan', sortable: true },
+  { key: 'noSurat', label: 'No. Surat (Renew/Tamat)', sortable: true },
+  { key: 'tarikhTindakan', label: 'Tarikh Tindakan', sortable: true },
+  { key: 'tempohBulan', label: 'Tempoh (bulan)', sortable: true },
+  { key: 'sebabPenamatan', label: 'Sebab Penamatan', sortable: true },
+  { key: 'statusSerahTugas', label: 'Status Serah Tugas', sortable: true },
+  { key: 'pegawaiPelulus', label: 'Pegawai Pelulus', sortable: true },
+  { key: 'catatan', label: 'Catatan', sortable: false },
+]
+
+/* ================== Modal (Click-through) ================== */
+const modal = reactive({ open: false, title: '', rows: [] as any[] })
+const modalColumns = [
+  { key: 'nama', label: 'Nama' },
+  { key: 'kategoriPA', label: 'Kategori PA' },
+  { key: 'lokasi', label: 'Lokasi' },
+  { key: 'tugasan', label: 'Tugasan' },
+  { key: 'statusPA', label: 'Status PA' },
+  { key: 'tarikhMula', label: 'Tarikh Mula' },
+  { key: 'tarikhTamat', label: 'Tarikh Tamat' },
+]
+function openModalIndividu(title: string, rows: any[]) {
+  modal.title = title
+  modal.rows = rows
+  modal.open = true
+}
+
+/* ================== Export (PDF / Excel) ================== */
+function exportXLSX(which: 'tugasan' | 'status' | 'elaun') {
+  const map = {
+    tugasan: { rows: laporanTugasan.value, name: 'Laporan_Tugasan' },
+    status:  { rows: laporanStatus.value,  name: 'Laporan_Status_Pendaftaran' },
+    elaun:   { rows: laporanElaun.value,   name: 'Laporan_Elaun' },
+  } as const
+  const { rows, name } = map[which]
+  // If SheetJS (XLSX) is available globally, use it; otherwise fall back to CSV.
+  // @ts-ignore
+  if (window && window.XLSX) {
+    // @ts-ignore
+    const ws = window.XLSX.utils.json_to_sheet(rows)
+    // @ts-ignore
+    const wb = window.XLSX.utils.book_new()
+    // @ts-ignore
+    window.XLSX.utils.book_append_sheet(wb, ws, 'Sheet1')
+    // @ts-ignore
+    const wbout = window.XLSX.write(wb, { bookType: 'xlsx', type: 'array' })
+    const blob = new Blob([wbout], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+    downloadBlob(blob, `${name}.xlsx`)
+  } else {
+    exportCSVRows(rows, `${name}.csv`)
+  }
+}
+
+function exportPDF(which: 'tugasan' | 'status' | 'elaun') {
+  const title = {
+    tugasan: 'Laporan Tugasan',
+    status: 'Laporan Status Pendaftaran',
+    elaun: 'Laporan Elaun'
+  }[which]
+  const rows = {
+    tugasan: laporanTugasan.value,
+    status: laporanStatus.value,
+    elaun: laporanElaun.value
+  }[which]
+
+  const tableHTML = jsonToHTMLTable(rows)
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>${title}</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 24px; }
+    h1 { font-size: 18px; margin-bottom: 12px; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ddd; padding: 8px; font-size: 12px; }
+    th { background: #f2f2f2; text-align: left; }
+  </style>
+</head>
+<body onload="window.print(); setTimeout(()=>window.close(),300)">
+  <h1>${title}</h1>
+  ${tableHTML}
+</body>
+</html>`
+
+  const win = window.open('', '_blank')
+  if (win) {
+    win.document.open()
+    win.document.write(html)
+    win.document.close()
+  }
+}
+
+/* ================== Router navigation ================== */
+const router = useRouter()
+function goToJanaLaporan() {
+  router.push('/BF-PA/DA/dashboard/jana-laporan-pendaftaran')
+}
+function goToJanaLaporanElaun() {
+  router.push('/BF-PA/DA/dashboard/jana-laporan-elaun')
+}
+function goToJanaLaporanTugasan() {
+  router.push('/BF-PA/DA/dashboard/jana-laporan-tugasan')
+}
+function goToJanaLaporanPenamatan() {
+  router.push('/BF-PA/DA/dashboard/jana-laporan-penamatan')
+}
+
+/* ================== watchers ================== */
+watch(nonce, () => {
+  // place to re-fetch if wired to API
+})
+</script>
+
+<style scoped>
+.fade-enter-active, .fade-leave-active { transition: opacity .15s ease; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+</style>

--- a/pages/BF-PA/DA/dashboard/jana-laporan-tugasan/index.vue
+++ b/pages/BF-PA/DA/dashboard/jana-laporan-tugasan/index.vue
@@ -1,0 +1,454 @@
+<template>
+  <div class="space-y-4">
+    <!-- Breadcrumb -->
+    <LayoutsBreadcrumb :items="breadcrumb" />
+
+    <!-- ===== 3.1.1 Tajuk / Meta Laporan ===== -->
+    <rs-card>
+      <template #header>
+        <div class="flex items-center justify-between w-full">
+          <div class="flex items-center gap-3">
+            <Icon name="mdi:file-document-outline" />
+            <span class="font-semibold">Laporan Tugasan Penolong Amil</span>
+          </div>
+          <div class="flex gap-2">
+            <rs-button variant="primary" @click="onPrint">Cetak</rs-button>
+            <rs-button variant="soft" @click="exportXLSX">Excel (XLSX)</rs-button>
+            <rs-button variant="soft" @click="exportCSV">CSV</rs-button>
+          </div>
+        </div>
+      </template>
+      <template #body>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div class="space-y-1">
+            <div><span class="font-medium">Tajuk Laporan:</span>Laporan Tugasan Penolong Amil</div>
+            <div><span class="font-medium">Organisasi:</span> Lembaga Zakat Selangor</div>
+            <div><span class="font-medium">Klasifikasi:</span> <rs-badge variant="soft">Dalaman</rs-badge></div>
+          </div>
+          <div class="space-y-1">
+            <div><span class="font-medium">Dijana Oleh:</span> {{ generatedBy }}</div>
+            <div><span class="font-medium">Tarikh/Capa Masa Jana:</span> {{ generatedAtLabel }}</div>
+            <div><span class="font-medium">Tempoh:</span> Tahun {{ filters.tahun }}<span v-if="filters.bulan !== 'ALL'">, Bulan {{ filters.bulan }}</span></div>
+          </div>
+          <div class="space-y-1">
+            <div class="font-medium">Ringkasan Penapis</div>
+            <div>Daerah: {{ filters.daerah === 'ALL' ? 'Semua' : filters.daerah }}</div>
+            <div>Kategori PA: {{ filters.kategori === 'ALL' ? 'Semua' : filters.kategori }}</div>
+            <div>Jenis Tugasan: {{ filters.jenisTugasan === 'ALL' ? 'Semua' : filters.jenisTugasan }}</div>
+          </div>
+        </div>
+
+        <!-- Penapis ringkas + pilihan kumpul -->
+        <div class="grid grid-cols-1 md:grid-cols-6 gap-3 mt-4">
+          <FormKit type="select" v-model="filters.tahun" label="Tahun" :options="tahunOptions" />
+          <FormKit type="select" v-model="filters.bulan" label="Bulan" :options="bulanOptions" />
+          <FormKit type="select" v-model="filters.daerah" label="Daerah" :options="daerahOptions" />
+          <FormKit type="select" v-model="filters.kategori" label="Kategori PA" :options="kategoriOptions" />
+          <FormKit type="select" v-model="filters.jenisTugasan" label="Jenis Tugasan" :options="jenisTugasanOptions" />
+          <div>
+            <label class="block text-sm font-medium mb-1">Kumpul Mengikut</label>
+            <div class="flex items-center gap-3">
+              <label class="flex items-center gap-2 text-sm">
+                <input type="radio" value="KARIAH" v-model="groupBy" />
+                Kariah
+              </label>
+              <label class="flex items-center gap-2 text-sm">
+                <input type="radio" value="DAERAH" v-model="groupBy" />
+                Daerah
+              </label>
+            </div>
+          </div>
+        </div>
+      </template>
+    </rs-card>
+
+    <!-- ===== 3.2.2 Grup: Jenis Tugasan → (Kariah|Daerah) → Kategori PA ===== -->
+    <div v-for="(byLoc, jenis) in grouped" :key="jenis" class="report-section print-break">
+      <div class="flex items-center justify-between mt-2 mb-1">
+        <div class="text-lg font-semibold flex items-center gap-2">
+          <Icon name="mdi:clipboard-list-outline" /> Jenis Tugasan: {{ jenis }}
+        </div>
+        <rs-badge variant="soft">Klasifikasi: Dalaman</rs-badge>
+      </div>
+      <div class="text-sm text-gray-600 mb-3">Kumpulan: {{ groupBy === 'KARIAH' ? 'Kariah' : 'Daerah' }} → Kategori PA</div>
+
+      <div v-for="(byKategori, loc) in byLoc" :key="loc" class="mb-8">
+        <div class="font-medium mb-2 flex items-center gap-2">
+          <Icon name="mdi:map-marker-radius-outline" />
+          <span>{{ groupBy === 'KARIAH' ? 'Kariah' : 'Daerah' }}: {{ loc }}</span>
+        </div>
+
+        <div v-for="(rows, kategori) in byKategori" :key="kategori" class="mb-6">
+          <div class="mb-2 text-sm text-gray-700 flex items-center gap-2">
+            <Icon name="mdi:shield-account-outline" /> Kategori PA: {{ kategori }}
+          </div>
+
+          <RsTable
+            :data="rows"
+            :columns="columns"
+            :showNoColumn="false"
+            :showSearch="false"
+            :showFilter="false"
+            :options="{ variant: 'default', striped: true, hover: false, borderless: false }"
+            :optionsAdvanced="{ sortable: true, filterable: false, responsive: true, outsideBorder: true }"
+            advanced
+          >
+            <!-- Formatters mengikut URS -->
+            <template #tarikhTugasan="{ text }">{{ formatDate(text) }}</template>
+            <template #amaunUnitRM="{ text }">{{ formatRM(Number(text)) }}</template>
+            <template #jumlahElaunRM="{ text }">{{ formatRM(Number(text)) }}</template>
+          </RsTable>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== 3.3 Rangkuman Padanan Log ===== -->
+    <rs-card>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <Icon name="mdi:clipboard-check-outline" />
+          <span class="font-semibold">Rangkuman Padanan Log</span>
+        </div>
+      </template>
+      <template #body>
+        <div v-if="logsSummary.length > 0" class="space-y-1">
+          <div v-for="(log, i) in logsSummary" :key="i" class="text-sm">
+            • Disahkan oleh <b>{{ log.nama }}</b> pada <b>{{ formatDate(log.tarikh) }}</b> — {{ log.count }} tugasan
+          </div>
+        </div>
+        <div v-else class="text-sm text-gray-500">Tiada rekod pengesahan untuk paparan semasa.</div>
+      </template>
+    </rs-card>
+
+    <!-- Footer / Cetakan -->
+    <div class="bg-white rounded-2xl border p-5 space-y-6">
+      <div class="text-xs text-gray-500">
+        Klasifikasi: Dalaman • Dihasilkan pada {{ generatedAtLabel }} • “Muka surat” dipapar dalam mod cetak.
+      </div>
+    </div>
+
+    <div class="page-footer print-only">Muka surat <span class="page-number"></span> / <span class="total-pages"></span></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * PA-DA-PD-02 (Tugasan) —Laporan Tugasan Penolong Amil
+ * - Header/meta, filters
+ * - Table columns (read-only) with MYR/Date formatting
+ * - Grouping: Jenis Tugasan → (Kariah|Daerah) → Kategori PA
+ * - Jumlah Elaun (RM) = Amaun Unit × Bil. Unit
+ * - Rangkuman padanan log: “Disahkan oleh [nama] pada [tarikh]”
+ */
+import { ref, reactive, computed } from 'vue'
+
+defineOptions({ name: 'PA-DA-PD-02-Tugasan' })
+
+/* ===== Breadcrumb ===== */
+const breadcrumb = ref([
+  { name: 'Dashboard', type: 'text', path: '/' },
+  { name: 'Laporan Tugasan', type: 'text', path: '#' },
+])
+
+/* ===== Filters ===== */
+const filters = reactive({
+  tahun: new Date().getFullYear().toString(),
+  bulan: 'ALL', // 01..12 or ALL
+  daerah: 'ALL',
+  kategori: 'ALL',       // PAK/PAF/PAP/PAK+ / ALL
+  jenisTugasan: 'ALL',   // BANCIAN BARU / KEMASKINI / PERMOHONAN BANTUAN / ALL
+})
+const groupBy = ref<'KARIAH' | 'DAERAH'>('KARIAH')
+
+const tahunOptions = [
+  { label: '2023', value: '2023' },
+  { label: '2024', value: '2024' },
+  { label: '2025', value: '2025' },
+]
+const bulanOptions = [
+  { label: 'Semua', value: 'ALL' },
+  ...Array.from({ length: 12 }, (_, i) => {
+    const m = String(i + 1).padStart(2, '0')
+    return { label: m, value: m }
+  }),
+]
+const daerahOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'Gombak', value: 'Gombak' },
+  { label: 'Klang', value: 'Klang' },
+  { label: 'Hulu Langat', value: 'Hulu Langat' },
+  { label: 'Kuala Selangor', value: 'Kuala Selangor' },
+]
+const kategoriOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'PAK', value: 'PAK' },
+  { label: 'PAF', value: 'PAF' },
+  { label: 'PAP', value: 'PAP' },
+  { label: 'PAK+', value: 'PAK+' },
+]
+const jenisTugasanOptions = [
+  { label: 'Semua', value: 'ALL' },
+  { label: 'BANCIAN BARU', value: 'BANCIAN BARU' },
+  { label: 'KEMASKINI', value: 'KEMASKINI' },
+  { label: 'PERMOHONAN BANTUAN', value: 'PERMOHONAN BANTUAN' },
+]
+
+/* ===== Meta ===== */
+const generatedBy = ref('Pengguna Sistem')
+const generatedAt = ref(new Date())
+const generatedAtLabel = computed(() => {
+  return generatedAt.value.toLocaleString('ms-MY', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+    hour: '2-digit', minute: '2-digit', second: '2-digit'
+  })
+})
+
+/* ===== Mock Data ===== */
+type Row = {
+  tarikhTugasan: string // ISO
+  idTugasan: string
+  idPA: string
+  nama: string
+  kategoriPA: 'PAK' | 'PAF' | 'PAP' | 'PAK+'
+  jenisTugasan: 'BANCIAN BARU' | 'KEMASKINI' | 'PERMOHONAN BANTUAN'
+  rujukan: string
+  bilUnit: number
+  amaunUnitRM: number          // kadar pada tarikh tugasan
+  statusPengesahan: string     // text
+  statusPembayaran: string     // text
+  pegawaiPenyemak: string
+  kariahDaerah: string         // "Kariah XYZ / Gombak"
+  catatan?: string
+  disahkanOleh?: string
+  tarikhSah?: string           // ISO
+}
+
+const rowsAll = ref<Row[]>([
+  {
+    tarikhTugasan: '2025-09-01', idTugasan: 'TG-0001', idPA: 'PA0001', nama: 'Ahmad Karim',
+    kategoriPA: 'PAK', jenisTugasan: 'BANCIAN BARU', rujukan: 'BRG-2025-0001',
+    bilUnit: 1, amaunUnitRM: 30, statusPengesahan: 'Disahkan', statusPembayaran: 'SUDAH DIBAYAR',
+    pegawaiPenyemak: 'En. Razak', kariahDaerah: 'Al-Hidayah / Gombak', catatan: '',
+    disahkanOleh: 'En. Razak', tarikhSah: '2025-09-02'
+  },
+  {
+    tarikhTugasan: '2025-09-04', idTugasan: 'TG-0002', idPA: 'PA0002', nama: 'Siti Rahmah',
+    kategoriPA: 'PAF', jenisTugasan: 'KEMASKINI', rujukan: 'UPD-2025-051',
+    bilUnit: 2, amaunUnitRM: 25, statusPengesahan: 'Disahkan', statusPembayaran: 'BELUM DIBAYAR',
+    pegawaiPenyemak: 'Pn. Mariam', kariahDaerah: 'An-Nur / Gombak', catatan: '—',
+    disahkanOleh: 'Pn. Mariam', tarikhSah: '2025-09-05'
+  },
+  {
+    tarikhTugasan: '2025-08-30', idTugasan: 'TG-0101', idPA: 'PA0101', nama: 'Lim Wei',
+    kategoriPA: 'PAP', jenisTugasan: 'PERMOHONAN BANTUAN', rujukan: 'APP-2025-100',
+    bilUnit: 1, amaunUnitRM: 50, statusPengesahan: 'Sahkan Kemudian', statusPembayaran: 'BELUM DIBAYAR',
+    pegawaiPenyemak: 'En. Farid', kariahDaerah: '— / Klang', catatan: ''
+  },
+  {
+    tarikhTugasan: '2025-09-03', idTugasan: 'TG-0203', idPA: 'PA0203', nama: 'Anand',
+    kategoriPA: 'PAK+', jenisTugasan: 'BANCIAN BARU', rujukan: 'BRG-2025-0003',
+    bilUnit: 3, amaunUnitRM: 20, statusPengesahan: 'Disahkan', statusPembayaran: 'SUDAH DIBAYAR',
+    pegawaiPenyemak: 'Pn. Noraini', kariahDaerah: '— / Hulu Langat', catatan: '—',
+    disahkanOleh: 'Pn. Noraini', tarikhSah: '2025-09-04'
+  },
+])
+
+/* ===== Utils ===== */
+function formatRM(v: number) {
+  return new Intl.NumberFormat('ms-MY', { style: 'currency', currency: 'MYR' }).format(v || 0)
+}
+function formatDate(iso?: string) {
+  if (!iso) return '-'
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return '-'
+  const dd = String(d.getDate()).padStart(2, '0')
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const yyyy = d.getFullYear()
+  return `${dd}/${mm}/${yyyy}`
+}
+function csvSafe(v: any) {
+  const s = String(v ?? '')
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`
+  }
+  return s
+}
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+/* ===== Filtered & Enriched (add jumlahElaunRM) ===== */
+const filteredRows = computed(() => {
+  return rowsAll.value.filter(r => {
+    if (filters.daerah !== 'ALL' && !r.kariahDaerah.endsWith(` / ${filters.daerah}`)) return false
+    if (filters.kategori !== 'ALL' && r.kategoriPA !== filters.kategori) return false
+    if (filters.jenisTugasan !== 'ALL' && r.jenisTugasan !== filters.jenisTugasan) return false
+    if (filters.tahun !== 'ALL' && !String(r.tarikhTugasan).startsWith(filters.tahun)) return false
+    if (filters.bulan !== 'ALL' && String(r.tarikhTugasan).slice(5, 7) !== filters.bulan) return false
+    return true
+  })
+})
+
+const tableRows = computed(() => {
+  return filteredRows.value.map(r => ({
+    ...r,
+    jumlahElaunRM: r.bilUnit * r.amaunUnitRM, // Peraturan: Jumlah = Amaun Unit × Bil. Unit
+  }))
+})
+
+/* ===== Grouped: Jenis Tugasan → (Kariah|Daerah) → Kategori PA ===== */
+const grouped = computed(() => {
+  const byJenis: Record<string, Record<string, Record<string, any[]>>> = {}
+  for (const r of tableRows.value) {
+    const jenis = r.jenisTugasan
+    if (!byJenis[jenis]) byJenis[jenis] = {}
+
+    // pilih lokasi ikut groupBy
+    const [kariahRaw, daerahRaw] = (r.kariahDaerah || ' / ').split('/')
+    const kariah = (kariahRaw || '—').trim()
+    const daerah = (daerahRaw || '—').trim()
+    const loc = groupBy.value === 'KARIAH' ? kariah : daerah
+
+    if (!byJenis[jenis][loc]) byJenis[jenis][loc] = {}
+    if (!byJenis[jenis][loc][r.kategoriPA]) byJenis[jenis][loc][r.kategoriPA] = []
+    byJenis[jenis][loc][r.kategoriPA].push(r)
+  }
+
+  // stable order
+  const jenisOrder = ['BANCIAN BARU', 'KEMASKINI', 'PERMOHONAN BANTUAN']
+  const kategoriOrder = ['PAK', 'PAF', 'PAP', 'PAK+']
+  const sorted: Record<string, Record<string, Record<string, any[]>>> = {}
+  Object.keys(byJenis).sort((a, b) => jenisOrder.indexOf(a) - jenisOrder.indexOf(b)).forEach(j => {
+    sorted[j] = {}
+    Object.keys(byJenis[j]).sort().forEach(loc => {
+      sorted[j][loc] = {}
+      Object.keys(byJenis[j][loc]).sort((a, b) => kategoriOrder.indexOf(a) - kategoriOrder.indexOf(b)).forEach(cat => {
+        sorted[j][loc][cat] = byJenis[j][loc][cat]
+      })
+    })
+  })
+  return sorted
+})
+
+/* ===== Logs Summary (3.3) ===== */
+const logsSummary = computed(() => {
+  // group by (disahkanOleh, tarikhSah)
+  const keyMap = new Map<string, { nama: string; tarikh: string; count: number }>()
+  for (const r of filteredRows.value) {
+    if (!r.disahkanOleh || !r.tarikhSah) continue
+    const key = `${r.disahkanOleh}|${r.tarikhSah}`
+    const prev = keyMap.get(key)
+    if (prev) {
+      prev.count += 1
+    } else {
+      keyMap.set(key, { nama: r.disahkanOleh, tarikh: r.tarikhSah, count: 1 })
+    }
+  }
+  return Array.from(keyMap.values()).sort((a, b) => (a.tarikh > b.tarikh ? -1 : 1))
+})
+
+/* ===== Table Columns ===== */
+const columns = [
+  { key: 'tarikhTugasan', label: 'Tarikh Tugasan', sortable: true },
+  { key: 'idTugasan', label: 'ID_Tugasan', sortable: true },
+  { key: 'idPA', label: 'ID_PA', sortable: true },
+  { key: 'nama', label: 'Nama', sortable: true },
+  { key: 'kategoriPA', label: 'Kategori PA', sortable: true },
+  { key: 'jenisTugasan', label: 'Jenis Tugasan', sortable: true },
+  { key: 'rujukan', label: 'Rujukan Borang/Permohonan', sortable: true },
+  { key: 'bilUnit', label: 'Bil. Unit', sortable: true },
+  { key: 'amaunUnitRM', label: 'Amaun Unit (RM)', sortable: true },
+  { key: 'jumlahElaunRM', label: 'Jumlah Elaun (RM)', sortable: true },
+  { key: 'statusPengesahan', label: 'Status Pengesahan', sortable: true },
+  { key: 'statusPembayaran', label: 'Status Pembayaran', sortable: true },
+  { key: 'pegawaiPenyemak', label: 'Pegawai Penyemak/Disahkan Oleh', sortable: true },
+  { key: 'kariahDaerah', label: 'Kariah/Daerah', sortable: true },
+  { key: 'catatan', label: 'Catatan', sortable: false },
+]
+
+/* ===== Export ===== */
+function rowsFlatForExport() {
+  return tableRows.value.map(r => ({
+    'Tarikh Tugasan': formatDate(r.tarikhTugasan),
+    ID_Tugasan: r.idTugasan,
+    ID_PA: r.idPA,
+    Nama: r.nama,
+    'Kategori PA': r.kategoriPA,
+    'Jenis Tugasan': r.jenisTugasan,
+    'Rujukan Borang/Permohonan': r.rujukan,
+    'Bil. Unit': r.bilUnit,
+    'Amaun Unit (RM)': r.amaunUnitRM,
+    'Jumlah Elaun (RM)': r.jumlahElaunRM,
+    'Status Pengesahan': r.statusPengesahan,
+    'Status Pembayaran': r.statusPembayaran,
+    'Pegawai Penyemak/Disahkan Oleh': r.pegawaiPenyemak,
+    'Kariah/Daerah': r.kariahDaerah,
+    Catatan: r.catatan ?? ''
+  }))
+}
+
+function exportCSV() {
+  const data = rowsFlatForExport()
+  if (data.length === 0) return
+  const headers = Object.keys(data[0])
+  const csv = [
+    headers.join(','),
+    ...data.map(row => headers.map(h => csvSafe(row[h as keyof typeof row])).join(','))
+  ].join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  downloadBlob(blob, `Laporan_Tugasan_PA_${filters.tahun}_${filters.bulan}.csv`)
+}
+
+function exportXLSX() {
+  const data = rowsFlatForExport()
+  // If SheetJS is available globally, use it; else fall back to CSV
+  // @ts-ignore
+  if (window && window.XLSX) {
+    // @ts-ignore
+    const ws = window.XLSX.utils.json_to_sheet(data)
+    // @ts-ignore
+    const wb = window.XLSX.utils.book_new()
+    // @ts-ignore
+    window.XLSX.utils.book_append_sheet(wb, ws, 'Data')
+    // @ts-ignore
+    const wbout = window.XLSX.write(wb, { bookType: 'xlsx', type: 'array' })
+    const blob = new Blob([wbout], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+    downloadBlob(blob, `Laporan_Tugasan_PA_${filters.tahun}_${filters.bulan}.xlsx`)
+  } else {
+    exportCSV()
+  }
+}
+
+/* ===== Cetak ===== */
+function onPrint() {
+  window.print()
+}
+</script>
+
+<style scoped>
+/* Page break per Jenis Tugasan (nice for printing) */
+@media print {
+  .print-break {
+    page-break-before: always;
+  }
+  .print-break:first-of-type {
+    page-break-before: auto;
+  }
+  .print-only { display: block !important; }
+  .page-footer {
+    position: fixed;
+    bottom: 0;
+    left: 0; right: 0;
+    padding: 6px 12px;
+    font-size: 10px;
+    text-align: right;
+  }
+}
+/* Hide footer on screen */
+.print-only { display: none; }
+</style>


### PR DESCRIPTION
Introduces a new 'Pelaporan' section in navigation with a dashboard and multiple report generation pages under /BF-PA/DA/dashboard. Implements dashboard statistics, charts, filters, and report pages for elaun, penamatan, pendaftaran, statistik, and tugasan, including mock data and export features.